### PR TITLE
Set external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,40 @@ _**N.B.** This repo is very specific to Casper. We've released it for others
 to share our approach, but we don't recommend using it in your production
 environment for the time being.`_
 
-## Working with Nightshade-Styles
+## Working with Nightshade Styles
 
-Install the repo with npm:
+Install the repo with npm. The following will install the latest in `master`.
 
 ```bash
-npm install CasperSleep/nightshade-styles.git#v1.1.0
+npm install CasperSleep/nightshade-styles.git
 ```
+
+We **highly recommend** installing a tag of the repo `#v1.1.0`.
 
 Include stylesheets in your application. To get all of our tooling and plugins,
 
 ```sass
-@import './node_modules/nightshade-styles/plugins/positioning';
-@import './node_modules/nightshade-styles/plugins/z-index';
-@import './node_modules/nightshade-styles/plugins/queries_config';
-@import './node_modules/nightshade-styles/plugins/visual_utilities';
-@import './node_modules/nightshade-styles/plugins/animations';
-@import './node_modules/nightshade-styles/plugins/arrows_config';
+// Third part dependencies
+@import './node_modules/accoutrement-color/sass/color;
+@import './node_modules/susy;
 
-@import './node_modules/nightshade-styles/base/z-index_config';
-@import './node_modules/nightshade-styles/base/breakpoints_config';
-@import './node_modules/nightshade-styles/base/sizing_config';
-@import './node_modules/nightshade-styles/base/fonts_config';
-@import './node_modules/nightshade-styles/base/colors_config';
-@import './node_modules/nightshade-styles/base/typography/bundle';
-@import './node_modules/nightshade-styles/base/grids';
-@import './node_modules/nightshade-styles/base/base';
+
+
+@import './node_modules/@casper/nightshade-styles/utilities/positioning';
+@import './node_modules/@casper/nightshade-styles/utilities/z-index';
+@import './node_modules/@casper/nightshade-styles/utilities/queries_config';
+@import './node_modules/@casper/nightshade-styles/utilities/visual_utilities';
+@import './node_modules/@casper/nightshade-styles/utilities/animations';
+@import './node_modules/@casper/nightshade-styles/utilities/arrows_config';
+
+@import './node_modules/@casper/nightshade-styles/base/z-index_config';
+@import './node_modules/@casper/nightshade-styles/base/breakpoints_config';
+@import './node_modules/@casper/nightshade-styles/base/sizing_config';
+@import './node_modules/@casper/nightshade-styles/base/fonts_config';
+@import './node_modules/@casper/nightshade-styles/base/colors_config';
+@import './node_modules/@casper/nightshade-styles/base/typography/bundle';
+@import './node_modules/@casper/nightshade-styles/base/grids';
+@import './node_modules/@casper/nightshade-styles/base/base';
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ environment for the time being.`_
 
 Install the repo with npm:
 
-```
-npm install git+https://github.com/CasperSleep/nightshade-styles.git#v1.x.x
+```bash
+npm install CasperSleep/nightshade-styles.git#v1.1.0
 ```
 
 Include stylesheets in your application. To get all of our tooling and plugins,
 
-```
+```sass
 @import './node_modules/nightshade-styles/plugins/positioning';
 @import './node_modules/nightshade-styles/plugins/z-index';
 @import './node_modules/nightshade-styles/plugins/queries_config';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@casper/nightshade-styles",
   "version": "1.1.0",
-  "description": "Casper pattern and style scss library. Under development",
+  "description": "Casper pattern and style scss library. Under development.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "postversion": "git push && git push --tags"
@@ -16,7 +16,7 @@
     "url": "https://github.com/CasperSleep/nightshade-styles/issues"
   },
   "homepage": "https://github.com/CasperSleep/nightshade-styles#readme",
-  "devDependencies": {
+  "dependencies": {
     "accoutrement-a11y": "^1.0.6",
     "accoutrement-color": "^1.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/CasperSleep/nightshade-styles#readme",
   "dependencies": {
-    "accoutrement-a11y": "^1.0.6",
     "accoutrement-color": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
   "bugs": {
     "url": "https://github.com/CasperSleep/nightshade-styles/issues"
   },
-  "homepage": "https://github.com/CasperSleep/nightshade-styles#readme"
+  "homepage": "https://github.com/CasperSleep/nightshade-styles#readme",
+  "devDependencies": {
+    "accoutrement-a11y": "^1.0.6",
+    "accoutrement-color": "^1.0.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/CasperSleep/nightshade-styles#readme",
   "dependencies": {
-    "accoutrement-color": "^1.0.3"
+    "accoutrement-color": "^1.0.3",
+    "susy": "^2.2.11"
   }
 }


### PR DESCRIPTION
This PR adds our external sass libraries as dependencies. 
## Expected results
- When the package is installed, external libraries will also be installed in `node_modules`
