### PR TITLE
Update trial warranty blue

### DIFF
--- a/base/_colors_config.scss
+++ b/base/_colors_config.scss
@@ -141,7 +141,7 @@ $colors: (
 
   // Individual components
 
-  trial-warranty: #28275b,
+  trial-warranty: #001856,
   product-gallery-background: lightest-grey,
   footer-bottom-icon: #6576a0,
   header-text: darker-grey,


### PR DESCRIPTION
I believe we had changed this before, but `trial-warranty` should be #001856

![image](https://cloud.githubusercontent.com/assets/7387858/13060022/68c03224-d3fc-11e5-8b55-a7914e5bad28.png)
