### PR TITLE
Bump to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/nightshade-styles",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Casper pattern and style scss library. Under development.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Really this is a breaking change (as seen on Casper.com), but keeping a minor
version as requested in PR 31.
