### PR TITLE
Remove reference to Verlag Black

### DIFF
--- a/base/_fonts_config.scss
+++ b/base/_fonts_config.scss
@@ -45,27 +45,24 @@ $serif-stack: Georgia, serif;
 
 %verlag {
   @extend %sans-family-stack;
-
   font-weight: 400;
   font-style: normal;
 }
 
 %verlag-light {
   @extend %sans-family-stack;
-
   font-weight: 300;
   font-style: normal;
 }
 
 %verlag-black {
-  font-family: "Verlag Black A", "Verlag Black B", $sans-stack;
+  @extend %sans-family-stack;
   font-weight: 800;
   font-style: normal;
 }
 
 %chronicle-deck {
   @extend %serif-family-stack;
-
   font-weight: 400;
   font-style: normal;
 }
@@ -78,7 +75,6 @@ $serif-stack: Georgia, serif;
 
 %chronicle-italic {
   @extend %serif-family-stack;
-
   font-weight: 400;
   font-style: italic;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/nightshade-styles",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Casper pattern and style scss library. Under development.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Our Typography.com bundle was including two versions of Verlag Black. The Verlag library includes Verlag Black.

Also got to remove Verlag bold from our bundle.

Total savings: 53kb 
- [Cleanup] Whitespace
