### PR TITLE
Update font references to work with Webfontloader

### DIFF
--- a/base/_base.scss
+++ b/base/_base.scss
@@ -41,7 +41,7 @@ html {
   &,
   &:before,
   &:after {
-    box-sizing: border-box;
+    box-sizing: inherit;
   }
 }
 

--- a/base/_base.scss
+++ b/base/_base.scss
@@ -21,7 +21,6 @@
  */
 
 html {
-  @extend %verlag-light;
   box-sizing: border-box;
   background: color(background);
   color: color(text);
@@ -36,17 +35,18 @@ html {
   -ms-text-size-adjust: 100%; // [5]
   -webkit-font-smoothing: antialiased; // [6]
   -moz-osx-font-smoothing: grayscale; // [6]
+}
 
-  * {
-    &,
-    &:before,
-    &:after {
-      box-sizing: border-box;
-    }
+* {
+  &,
+  &:before,
+  &:after {
+    box-sizing: border-box;
   }
 }
 
 body {
+  @extend %verlag-light;
   margin: 0 auto;
   width: 100%;
 }

--- a/base/_fonts_config.scss
+++ b/base/_fonts_config.scss
@@ -29,52 +29,72 @@
 
  */
 
-$sans: "Verlag A", "Verlag B";
-$sans-stack: "Helvetica Neue", Helvetica, Arial, sans-serif;
+ $verlag: "Verlag A", "Verlag B";
+ $verlag-black: "Verlag Black A", "Verlag Black B";
+ $chronicle-deck: "Chronicle Deck A", "Chronicle Deck B";
+ $chronicle-display: "Chronicle SSm A", "Chronicle SSm B";
 
-$serif: "Chronicle Deck A", "Chronicle Deck B";
-$serif-stack: Georgia, serif;
+ $sans-stack: "Helvetica Neue", Helvetica, Arial, sans-serif;
+ $serif-stack: Georgia, serif;
 
-%sans-family-stack {
-  font-family: $sans, $sans-stack;
-}
 
-%serif-family-stack {
-  font-family: $serif, $serif-stack;
-}
+ %verlag {
+   font-family: $sans-stack;
+   font-weight: 400;
+   font-style: normal;
 
-%verlag {
-  @extend %sans-family-stack;
-  font-weight: 400;
-  font-style: normal;
-}
+   .wf-active & {
+     font-family: $verlag;
+   }
+ }
 
-%verlag-light {
-  @extend %sans-family-stack;
-  font-weight: 300;
-  font-style: normal;
-}
+ %verlag-light {
+   font-family: $sans-stack;
+   font-weight: 300;
+   font-style: normal;
 
-%verlag-black {
-  @extend %sans-family-stack;
-  font-weight: 800;
-  font-style: normal;
-}
+   .wf-active & {
+     font-family: $verlag;
+   }
+ }
 
-%chronicle-deck {
-  @extend %serif-family-stack;
-  font-weight: 400;
-  font-style: normal;
-}
+ %verlag-black {
+   font-family: $sans-stack;
+   font-weight: 800;
+   font-style: normal;
 
-%chronicle-display {
-  font-family: "Chronicle SSm A", "Chronicle SSm B", $serif-stack;
-  font-weight: 400;
-  font-style: normal;
-}
+   .wf-active & {
+     font-family: $verlag-black;
+   }
+ }
 
-%chronicle-italic {
-  @extend %serif-family-stack;
-  font-weight: 400;
-  font-style: italic;
-}
+ %chronicle-deck {
+   font-family: $serif-stack;
+   font-weight: 400;
+   font-style: normal;
+
+   .wf-active & {
+     font-family: $chronicle-deck;
+   }
+ }
+
+ %chronicle-display {
+   font-family: $serif-stack;
+   font-weight: 400;
+   font-style: normal;
+
+   .wf-active & {
+     font-family: $chronicle-display;
+   }
+ }
+
+ %chronicle-italic {
+   font-family: $serif-stack;
+   font-weight: 400;
+   font-style: italic;
+
+   .wf-active & {
+     font-family: $chronicle-deck;
+   }
+ }
+ 

--- a/base/typography/_paragraphs_config.scss
+++ b/base/typography/_paragraphs_config.scss
@@ -55,10 +55,12 @@ laid down and counted the sheep. Sleep head was laying down counting sheep.
   font-size: 16px;
 
   @include respond-at-and-above(640px) {
-    //@@@ TODO switch to chronicle deck?
-    font-family: $serif, $serif-stack;
     font-weight: 400;
     font-style: normal;
+
+    .wf-active & {
+      font-family: $chronicle-deck;
+    }
   }
 
   @include respond-between(640px, $break-large) {
@@ -104,5 +106,3 @@ laid down and counted the sheep. Sleep head was laying down counting sheep.
     line-height: 1.4;
   }
 }
-
-


### PR DESCRIPTION
This is tied to https://github.com/CasperSleep/Casper/pull/2860, which should be merged after this and reference the updated version of `nightshade-core`
