### PR TITLE
Remove font loading, use styles from new bundle

### DIFF
--- a/base/_fonts_config.scss
+++ b/base/_fonts_config.scss
@@ -29,72 +29,45 @@
 
  */
 
- $verlag: "Verlag A", "Verlag B";
- $verlag-black: "Verlag Black A", "Verlag Black B";
- $chronicle-deck: "Chronicle Deck A", "Chronicle Deck B";
- $chronicle-display: "Chronicle SSm A", "Chronicle SSm B";
+$verlag: "Verlag A", "Verlag B";
+$chronicle-deck: "Chronicle Deck A", "Chronicle Deck B";
+$chronicle-display: "Chronicle SSm A", "Chronicle SSm B";
 
- $sans-stack: "Helvetica Neue", Helvetica, Arial, sans-serif;
- $serif-stack: Georgia, serif;
+$sans-stack: "Helvetica Neue", Helvetica, Arial, sans-serif;
+$serif-stack: Georgia, serif;
 
+%verlag {
+  font-family: $verlag, $sans-stack;
+  font-weight: 400;
+  font-style: normal;
+}
 
- %verlag {
-   font-family: $sans-stack;
-   font-weight: 400;
-   font-style: normal;
+%verlag-light {
+  font-family: $verlag, $sans-stack;
+  font-weight: 300;
+  font-style: normal;
+}
 
-   .wf-active & {
-     font-family: $verlag;
-   }
- }
+%verlag-black {
+  font-family: $verlag, $sans-stack;
+  font-weight: 800;
+  font-style: normal;
+}
 
- %verlag-light {
-   font-family: $sans-stack;
-   font-weight: 300;
-   font-style: normal;
+%chronicle-deck {
+  font-family: $chronicle-deck, $serif-stack;
+  font-weight: 400;
+  font-style: normal;
+}
 
-   .wf-active & {
-     font-family: $verlag;
-   }
- }
+%chronicle-display {
+  font-family: $chronicle-display, $serif-stack;
+  font-weight: 400;
+  font-style: normal;
+}
 
- %verlag-black {
-   font-family: $sans-stack;
-   font-weight: 800;
-   font-style: normal;
-
-   .wf-active & {
-     font-family: $verlag-black;
-   }
- }
-
- %chronicle-deck {
-   font-family: $serif-stack;
-   font-weight: 400;
-   font-style: normal;
-
-   .wf-active & {
-     font-family: $chronicle-deck;
-   }
- }
-
- %chronicle-display {
-   font-family: $serif-stack;
-   font-weight: 400;
-   font-style: normal;
-
-   .wf-active & {
-     font-family: $chronicle-display;
-   }
- }
-
- %chronicle-italic {
-   font-family: $serif-stack;
-   font-weight: 400;
-   font-style: italic;
-
-   .wf-active & {
-     font-family: $chronicle-deck;
-   }
- }
- 
+%chronicle-italic {
+  font-family: $chronicle-deck, $serif-stack;
+  font-weight: 400;
+  font-style: italic;
+}

--- a/base/_fonts_config.scss
+++ b/base/_fonts_config.scss
@@ -52,6 +52,7 @@ $serif-stack: Georgia, serif;
   font-family: $verlag, $sans-stack;
   font-weight: 800;
   font-style: normal;
+  text-transform: uppercase; // @todo: Update content to desired case, remove transform
 }
 
 %chronicle-deck {

--- a/base/_fonts_config.scss
+++ b/base/_fonts_config.scss
@@ -52,7 +52,7 @@ $serif-stack: Georgia, serif;
   font-family: $verlag, $sans-stack;
   font-weight: 800;
   font-style: normal;
-  text-transform: uppercase; // @todo: Update content to desired case, remove transform
+  text-transform: uppercase; // @todo: Address for i18n. Update content to desired case, remove transform
 }
 
 %chronicle-deck {

--- a/base/typography/_headings_config.scss
+++ b/base/typography/_headings_config.scss
@@ -26,7 +26,6 @@ Responsive size breakpoints are baked into each element or its respective class.
 // Headers
 %headers {
   @extend %verlag-black;
-  text-transform: uppercase;
   letter-spacing: size(normal-tracking);
   margin-top: 0
 }

--- a/base/typography/_paragraphs_config.scss
+++ b/base/typography/_paragraphs_config.scss
@@ -55,12 +55,7 @@ laid down and counted the sheep. Sleep head was laying down counting sheep.
   font-size: 16px;
 
   @include respond-at-and-above(640px) {
-    font-weight: 400;
-    font-style: normal;
-
-    .wf-active & {
-      font-family: $chronicle-deck;
-    }
+    font-family: $chronicle-deck, $serif-stack;
   }
 
   @include respond-between(640px, $break-large) {

--- a/modules/_buttons.scss
+++ b/modules/_buttons.scss
@@ -56,7 +56,6 @@
   text-align: center;
   padding: 1.15em 3em;
   letter-spacing: size(medium-tracking);
-  text-transform: uppercase;
 
   // Native disabled attribute is preferred over state class
   &:disabled,


### PR DESCRIPTION
Tied to https://github.com/CasperSleep/Casper/pull/2925 which should be merged after this, once `npm version` is run, and the newest version of `nightshade-core` is referenced.
