### PR TITLE
Remove color macros (moved to Nightshade)

### DIFF
--- a/src/color/color.macros.html
+++ b/src/color/color.macros.html
@@ -1,8 +1,0 @@
-{% macro color_swatch(name, hex=null, cmyk=null) %}
-<div class="color-swatches-item">
-  <div class="color-swatches-swatch {{ name }}"></div>
-  <code class="color-swatches-name">{{ name }}</code>
-  <code class="color-swatches-hex">{{ hex }}</code>
-  <code class="color-swatches-cmyk">{{ cmyk }}</code>
-</div>
-{% endmacro %}


### PR DESCRIPTION
Tied to https://github.com/CasperSleep/nightshade/pull/87, which should be merged before this.
