### PR TITLE
Add more base styling to accordion pattern

### DIFF
--- a/src/accordion/Accordion.js
+++ b/src/accordion/Accordion.js
@@ -13,6 +13,7 @@ export const Accordion = {
   /**
    * Inits accordion elements
    * @param {string} accordionEl Accordion DOM Element
+   * @param {integer} [time=300] Duration for open/close transition in the Accordion
    * @returns {void}
   */
   init(accordionEl, time = 300) {

--- a/src/accordion/Accordion.js
+++ b/src/accordion/Accordion.js
@@ -6,6 +6,7 @@
 export const Accordion = {
 
   accordionSection : `.js-accordion-section`,
+  accordionSectionContent : `.js-accordion-section-content`,
   accordionSectionTrigger: `.js-accordion-section-toggle`,
   openClass: `is-accordion-open`,
 
@@ -27,10 +28,12 @@ export const Accordion = {
       trigger.addEventListener(`pointerup`, (e) => {
         e.stopPropagation();
 
+        let sectionContent = el.querySelectorAll(this.accordionSectionContent);
+
         if (el.classList.contains(this.openClass)) {
-          this.closeAccordionSection(el);
+          this.closeAccordionSection(el, sectionContent);
         } else {
-          this.openAccordionSection(el);
+          this.openAccordionSection(el, sectionContent);
         }
       });
     });
@@ -41,9 +44,10 @@ export const Accordion = {
    * @param {object} section DOM element to toggle state class on
    * @returns {void}
   */
-  openAccordionSection(section) {
+  openAccordionSection(section, sectionContent) {
     section.setAttribute(`aria-expanded`, true)
     section.classList.add(this.openClass);
+    Velocity(sectionContent, `slideDown`);
   },
 
   /**
@@ -51,8 +55,9 @@ export const Accordion = {
    * @param {object} section DOM element to toggle state class on
    * @returns {void}
   */
-  closeAccordionSection(section) {
+  closeAccordionSection(section, sectionContent) {
     section.setAttribute(`aria-expanded`, false)
     section.classList.remove(this.openClass);
+    Velocity(sectionContent, `slideUp`);
   },
 };

--- a/src/accordion/Accordion.js
+++ b/src/accordion/Accordion.js
@@ -30,7 +30,7 @@ export const Accordion = {
       trigger.addEventListener(`pointerup`, (e) => {
         e.stopPropagation();
 
-        let sectionContent = el.querySelectorAll(this.accordionSectionContent);
+        let sectionContent = el.querySelector(this.accordionSectionContent);
 
         if (el.classList.contains(this.openClass)) {
           this.closeAccordionSection(el, sectionContent);

--- a/src/accordion/Accordion.js
+++ b/src/accordion/Accordion.js
@@ -9,6 +9,7 @@ export const Accordion = {
   accordionSectionContent : `.js-accordion-section-content`,
   accordionSectionTrigger: `.js-accordion-section-toggle`,
   openClass: `is-accordion-open`,
+  transitionDuration: 500,
 
   /**
    * Inits accordion elements
@@ -47,7 +48,7 @@ export const Accordion = {
   openAccordionSection(section, sectionContent) {
     section.setAttribute(`aria-expanded`, true)
     section.classList.add(this.openClass);
-    Velocity(sectionContent, `slideDown`);
+    Velocity(sectionContent, `slideDown`, this.transitionDuration);
   },
 
   /**
@@ -58,6 +59,6 @@ export const Accordion = {
   closeAccordionSection(section, sectionContent) {
     section.setAttribute(`aria-expanded`, false)
     section.classList.remove(this.openClass);
-    Velocity(sectionContent, `slideUp`);
+    Velocity(sectionContent, `slideUp`, this.transitionDuration);
   },
 };

--- a/src/accordion/Accordion.js
+++ b/src/accordion/Accordion.js
@@ -9,15 +9,15 @@ export const Accordion = {
   accordionSectionContent : `.js-accordion-section-content`,
   accordionSectionTrigger: `.js-accordion-section-toggle`,
   openClass: `is-accordion-open`,
-  transitionDuration: 500,
 
   /**
    * Inits accordion elements
    * @param {string} accordionEl Accordion DOM Element
    * @returns {void}
   */
-  init(accordionEl) {
+  init(accordionEl, time = 300) {
     this.accordion = document.querySelector(accordionEl);
+    this.transitionDuration = time;
     this.accordionSections = this.accordion.querySelectorAll(this.accordionSection);
 
     [...this.accordionSections].forEach((el) => {

--- a/src/accordion/_base.scss
+++ b/src/accordion/_base.scss
@@ -30,7 +30,8 @@
   display: flex;
 
   [data-icon="arrow"] {
-    float: right;
+    align-self: auto;
+    fill: currentColor;
     transform: rotate(90deg);
 
     .is-accordion-open & {

--- a/src/accordion/_base.scss
+++ b/src/accordion/_base.scss
@@ -6,7 +6,11 @@
  **/
 
 .accordion-list-item {
-   margin: ms(1) 0;
+   border-bottom: solid 1px color(border);
+
+   &:last-child {
+     border-bottom: 0;
+   }
  }
 
 .accordion-section-list {
@@ -15,6 +19,7 @@
   transition: max-height 0.3s ease-in-out;
 
   .is-accordion-open & {
+    padding-bottom: ms(1);
     max-height: 1000px;
 
     @include respond-at-and-above($break-medium) {
@@ -25,8 +30,11 @@
 
 .accordion-section-toggle {
   cursor: pointer;
+  padding: ms(1) 0;
+  margin-bottom: 0;
 
   [data-icon="arrow"] {
+    float: right;
     transform: rotate(90deg);
 
     .is-accordion-open & {

--- a/src/accordion/_base.scss
+++ b/src/accordion/_base.scss
@@ -14,18 +14,8 @@
  }
 
 .accordion-section-list {
-  overflow: hidden;
-  max-height: 0;
-  transition: max-height 0.3s ease-in-out;
-
-  .is-accordion-open & {
-    padding-bottom: ms(1);
-    max-height: 1000px;
-
-    @include respond-at-and-above($break-medium) {
-      max-height: 500px;
-    }
-  }
+  display: none;
+  padding-bottom: ms(1);
 }
 
 .accordion-section-toggle {
@@ -34,6 +24,7 @@
   margin-bottom: 0;
 
   [data-icon="arrow"] {
+    border: solid 1px black;
     float: right;
     transform: rotate(90deg);
 

--- a/src/accordion/_base.scss
+++ b/src/accordion/_base.scss
@@ -18,13 +18,18 @@
   padding-bottom: ms(1);
 }
 
+.accordion-section-toggle-content {
+  flex-grow: 1;
+  margin-bottom: 0;
+}
+
 .accordion-section-toggle {
   cursor: pointer;
   padding: ms(1) 0;
   margin-bottom: 0;
+  display: flex;
 
   [data-icon="arrow"] {
-    border: solid 1px black;
     float: right;
     transform: rotate(90deg);
 

--- a/src/accordion/_ie_styles.scss
+++ b/src/accordion/_ie_styles.scss
@@ -1,0 +1,18 @@
+/**
+ * @file Accordion IE9 styles
+ * @module Accordion
+ * @overview Accordion IE9 styles
+ */
+
+ .accordion-section-toggle-content {
+  display: inline-block;
+  width: percentage(9/10);
+}
+
+.accordion-section-toggle {
+
+  [data-icon="arrow"] {
+    display: inline-block;
+    width: percentage(1 / 10);
+  }
+}

--- a/src/accordion/accordion.macros.html
+++ b/src/accordion/accordion.macros.html
@@ -17,7 +17,7 @@
 <div class="accordion-section js-accordion-section{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
   <div class="accordion-section-toggle js-accordion-section-toggle">
     <h4 class="accordion-section-toggle-content">{{ data.toggle_content }}</h4>
-    {{ icon("arrow", size="tiny") }}
+    {{ icon("arrow", size="small") }}
   </div>
   <ul class="accordion-section-list js-accordion-section-content">
   {% for item in data.list %}

--- a/src/accordion/accordion.macros.html
+++ b/src/accordion/accordion.macros.html
@@ -15,7 +15,10 @@
 #}
 {% macro accordion_section(data, class=null, id=null) %}
 <div class="accordion-section js-accordion-section{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
-  <h4 class="accordion-section-toggle js-accordion-section-toggle">{{ data.toggle_content }} {{ icon("arrow", size="tiny") }}</h4>
+  <div class="accordion-section-toggle js-accordion-section-toggle">
+    <h4 class="accordion-section-toggle-content">{{ data.toggle_content }}</h4>
+    {{ icon("arrow", size="tiny") }}
+  </div>
   <ul class="accordion-section-list js-accordion-section-content">
   {% for item in data.list %}
     <li class="accordion-section-list-item">


### PR DESCRIPTION
This PR adds some more base styling to the accordion pattern
1)  Bottom border on all but the last accordion section
2)  Adjust spacing within the accordion toggle to increase target area
3)  Use flexbox to style the accordion toggle content and icon
4)  Use velocity to open and close the accordion
5)  Create a preliminary ie stylesheet, this will need more testing

I'm not sure why the icons aren't showing up in the nightshade repo at the moment, but the little black square is where it would be.

![screen shot 2016-04-22 at 4 31 48 pm](https://cloud.githubusercontent.com/assets/2967647/14754188/c6aa0394-08a7-11e6-87c2-77f45537227c.png)
