### PR TITLE
Update breadcrumbs styling

### DIFF
--- a/src/breadcrumbs/_base.scss
+++ b/src/breadcrumbs/_base.scss
@@ -2,7 +2,6 @@
  * @file Breadcrumbs
  * @module Breadcrumbs
  * @overview Styles for Casper breadcrumbs
- * @TODO: expand/solidify styling, here they have styles to support grey and blue (like on the main site)
  */
 
 .breadcrumbs {
@@ -21,23 +20,33 @@
   }
 }
 
-.breadcrumbs--dark {
-  
+// Styling for Breadcrumbs in the footer
+.breadcrumbs--footer {
+
   .breadcrumbs-link {
-    color: color(blue);
+    color: color(white);
+    opacity: 0.45;
+    transition: 0.25s opacity ease;
+
+    &:hover {
+      opacity: 1;
+    }
   }
 
-  [data-icon="arrow"],
+  .breadcrumbs-list-item {
+    color: color(white);
+    vertical-align: middle;
+
+    &:before {
+      opacity: 0.45;
+    }
+
+    &:first-child {
+      margin-top: -5px;
+    }
+  }
+
   [data-icon="casper-logo-mark"] {
-    fill: color(blue);
-  }
-}
-
-.breadcrumbs-list-item {
-  display: inline-block;
-  margin: 0 ms(-6);
-
-  &:first-child {
-    margin-left: 0;
+    fill: color(white);
   }
 }

--- a/src/breadcrumbs/_base.scss
+++ b/src/breadcrumbs/_base.scss
@@ -4,19 +4,43 @@
  * @overview Styles for Casper breadcrumbs
  */
 
-.breadcrumbs {
+.breadcrumbs-list-item {
+   display: inline-block;
+   margin-left: ms(-7);
+
+   &:before {
+     content: "\003E";
+     margin-right: ms(-7);
+   }
+
+   &:first-child {
+     margin-left: 0;
+
+     &:before {
+       display: none;
+     }
+   }
+
+   &:last-child {
+     pointer-events: none;
+   }
+ }
+
+ .breadcrumbs-link {
+   font-size: ms(-1);
+   letter-spacing: size(normal-tracking);
+ }
+
+
+// Styling for default Breadcrumbs
+.breadcrumbs--default {
 
   .breadcrumbs-link {
     color: color(text);
 
     &:hover {
-      border-color: currentColor;
+      color: color(blue);
     }
-  }
-
-  [data-icon="arrow"],
-  [data-icon="casper-logo-mark"] {
-    fill: color(text);
   }
 }
 

--- a/src/breadcrumbs/_base.scss
+++ b/src/breadcrumbs/_base.scss
@@ -1,6 +1,6 @@
 /**
  * @file Breadcrumbs
- * @module breadcrumbs
+ * @module Breadcrumbs
  * @overview Styles for Casper breadcrumbs
  * @TODO: expand/solidify styling, here they have styles to support grey and blue (like on the main site)
  */

--- a/src/breadcrumbs/_base.scss
+++ b/src/breadcrumbs/_base.scss
@@ -32,7 +32,9 @@
  }
 
 
-// Styling for default Breadcrumbs
+ /**
+  * Styling for default Breadcrumbs
+  */
 .breadcrumbs--default {
 
   .breadcrumbs-link {
@@ -44,7 +46,9 @@
   }
 }
 
-// Styling for Breadcrumbs in the footer
+/**
+ * Styling for footer Breadcrumbs
+ */
 .breadcrumbs--footer {
 
   .breadcrumbs-link {

--- a/src/breadcrumbs/breadcrumbs.macros.html
+++ b/src/breadcrumbs/breadcrumbs.macros.html
@@ -21,26 +21,15 @@
           {{ icon('casper-logo-mark', size='x-small') }}
         </a>
       </li>
-      <li class="breadcrumbs-list-item">
-        {{ icon('arrow', size='tiny') }}
-      </li>
     {% endif %}
 
     {% for item in data %}
-      {% if loop.first %}
-        <li class="breadcrumbs-list-item">
-          {{ link(item.content, href=item.href, class='breadcrumbs-link') }}
-        </li>
-      {% else %}
-        <li class="breadcrumbs-list-item">
-          {{ icon('arrow', size='tiny') }}
-        </li>
-        <li class="breadcrumbs-list-item">
-          {{ link(item.content, href=item.href, class='breadcrumbs-link') }}
-        </li>
-      {% endif %}
+      <li class="breadcrumbs-list-item">
+        <a class="breadcrumbs-link" href="item.href">
+          {{ item.content }}
+        </a>
+      </li>
     {% endfor %}
-
   </ol>
 </div>
 {% endmacro %}

--- a/src/breadcrumbs/breadcrumbs.macros.html
+++ b/src/breadcrumbs/breadcrumbs.macros.html
@@ -3,7 +3,6 @@
   * @module Breadcrumbs
 #}
 {% from 'nightshade-core/src/icons/icons.macros.html' import icon %}
-{% from 'nightshade-core/src/links/links.macros.html' import link %}
 
 {#
   * Renders Breadcrumbs

--- a/src/breadcrumbs/breadcrumbs.macros.html
+++ b/src/breadcrumbs/breadcrumbs.macros.html
@@ -7,16 +7,15 @@
 {#
   * Renders Breadcrumbs
   * @param {array} data - List of links for Breadcrumbs
-  * @param {string} [color] - Indicates the color theme for the Breadcrumbs
-  * @param {boolean} [logo=false] - Determines if the logo should be in the breadcrumbs
+  * @param {boolean} [footer=false] - Indicates if these are footer breadcrumbs
   * @param {string} [class] - Class name for style or JS targeting
   * @param {string} [id] - ID for JS targeting
 #}
 
-{% macro breadcrumbs(data, color=null, logo=false, class=null, id=null) %}
-<div class="breadcrumbs{% if color %} breadcrumbs--{{ color }}{% endif %}{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
+{% macro breadcrumbs(data, footer=false, class=null, id=null) %}
+<div class="breadcrumbs{% if footer %} breadcrumbs--footer{% else %} breadcrumbs--default{% endif %}{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
   <ol class="breadcrumbs-list">
-    {% if logo %}
+    {% if footer %}
       <li class="breadcrumbs-list-item">
         <a class="" href="./">
           {{ icon('casper-logo-mark', size='small') }}

--- a/src/breadcrumbs/breadcrumbs.macros.html
+++ b/src/breadcrumbs/breadcrumbs.macros.html
@@ -17,8 +17,8 @@
   <ol class="breadcrumbs-list">
     {% if footer %}
       <li class="breadcrumbs-list-item">
-        <a class="" href="./">
-          {{ icon('casper-logo-mark', size='small') }}
+        <a class="breadcrumbs-link" href="./">
+          {{ icon('casper-logo-mark', size='x-small') }}
         </a>
       </li>
       <li class="breadcrumbs-list-item">


### PR DESCRIPTION
This PR
1) removes the color option for the breadcrumbs macro
2) replaces the arrow icon with the '>' character
3) removes the use of the link macro in this instance
