### PR TITLE
Add circle.yml to use correct Node version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 5.10.1


### PR DESCRIPTION
### Issues

CircleCI checks are failing on `npm install` because it's using Circle's default Node version (0.10). My hope is that bumping the version to our 5.10.1 will fix this problem.
