### PR TITLE
Reduce size of arrow icon on the accordion

### DIFF
--- a/src/accordion/accordion.macros.html
+++ b/src/accordion/accordion.macros.html
@@ -17,7 +17,7 @@
 <div class="accordion-section js-accordion-section{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
   <div class="accordion-section-toggle js-accordion-section-toggle">
     <h4 class="accordion-section-toggle-content">{{ data.toggle_content }}</h4>
-    {{ icon("arrow", size="x-small") }}
+    {{ icon('arrow', size='x-small') }}
   </div>
   <ul class="accordion-section-list js-accordion-section-content">
   {% for item in data.list %}

--- a/src/accordion/accordion.macros.html
+++ b/src/accordion/accordion.macros.html
@@ -17,7 +17,7 @@
 <div class="accordion-section js-accordion-section{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
   <div class="accordion-section-toggle js-accordion-section-toggle">
     <h4 class="accordion-section-toggle-content">{{ data.toggle_content }}</h4>
-    {{ icon("arrow", size="small") }}
+    {{ icon("arrow", size="x-small") }}
   </div>
   <ul class="accordion-section-list js-accordion-section-content">
   {% for item in data.list %}


### PR DESCRIPTION
### Issues

Arrow icon on the accordion pattern was too big.
### Todos

Nothing.
### Impacted Areas

FAQ
### Steps to Reproduce

Current v2.0.0-dev branch accordions have arrow icons that are 24px by 24px (`data-size='small'`), this branch introduces icons that are 16px by 16px (`data-size='x-small'`)
