### PR TITLE
Fix breadcrumbs

### DIFF
--- a/src/breadcrumbs/_base.scss
+++ b/src/breadcrumbs/_base.scss
@@ -50,6 +50,7 @@
  * Styling for footer Breadcrumbs
  */
 .breadcrumbs--footer {
+  margin-bottom: ms(2);
 
   .breadcrumbs-link {
     color: color(white);

--- a/src/layout/regions.macros.html
+++ b/src/layout/regions.macros.html
@@ -18,7 +18,7 @@
 %}
 
 {% macro footer_content() %}
-  {{ breadcrumbs(breadcrumbs_data) }}
+  {{ breadcrumbs(breadcrumbs_data, footer=true) }}
   <nav class="footer-nav clearfix">
 
     <div class="footer-nav-left">

--- a/src/layout/regions.macros.html
+++ b/src/layout/regions.macros.html
@@ -7,11 +7,11 @@
 
 {% set breadcrumbs_data = [
   {
-    content: "Mattress",
+    content: "MATTRESS",
     href: "#"
   },
   {
-    content: "Full Mattress",
+    content: "FULL MATTRESS",
     href: "#"
   }
   ]


### PR DESCRIPTION
### Issues

I recently made some updates to the footer macro, this PR integrates those changes into the regions footer (used throughout Storefront Static).
### Todos

Updating any other footers throughout the site, I don't think there are other instances though.
### Impacted Areas

Anything that uses the regions macro/simple footer.
### Steps to Reproduce

The current footer on store front static has incorrect highlighting and spacing.  On this branch the highlighting and general styling more closely matches what we currently have for footer breadcrumbs.
