### PR TITLE
Move scale to a top level module, single file import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/nightshade-core",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Casper pattern and style scss library. Under development.",
   "scripts": {
     "eslint": "eslint src",

--- a/src/_core_imports.scss
+++ b/src/_core_imports.scss
@@ -8,6 +8,7 @@
 @import './node_modules/susy/sass/susy';
 
 @import 'color/index';
+@import 'scale/config';
 
 @import 'layout/positioning_helpers';
 @import 'utilities/queries_helpers';

--- a/src/_core_imports.scss
+++ b/src/_core_imports.scss
@@ -3,12 +3,11 @@
  * @overview Core site configuration files and helpers that don't generate output
  */
 
-@import './node_modules/modularscale-sass/stylesheets/modular-scale';
 @import './node_modules/accoutrement-color/sass/color';
 @import './node_modules/susy/sass/susy';
 
 @import 'color/index';
-@import 'scale/config';
+@import 'scale/index';
 
 @import 'layout/positioning_helpers';
 @import 'utilities/queries_helpers';

--- a/src/scale/_config.scss
+++ b/src/scale/_config.scss
@@ -1,6 +1,6 @@
 /**
  * @file Modular Scale
- * @file Typography
+ * @file Scale
  * @overview Initializes the Modular Scale Sass extension and scale defaults
  * @see http://www.modularscale.com/?16&px&1.2&sass&text
  */

--- a/src/scale/_index.scss
+++ b/src/scale/_index.scss
@@ -1,0 +1,2 @@
+@import "./node_modules/modularscale-sass/stylesheets/modular-scale";
+@import "config";

--- a/src/typography/_config.scss
+++ b/src/typography/_config.scss
@@ -1,4 +1,3 @@
-@import "modular_scale_config";
 @import "fonts_config";
 @import "headings_config";
 @import "lists_config";


### PR DESCRIPTION
### Issues

Currently modular scale is contained inside the typography directory. Modular scale itself is being used for more than type; padding, margin, spacing. In the rails app I'd like to import modular scale without typography mixins / changes, and be clear in the code that I'm doing so.

Currently we need to import two files in order to use modular scale. I'd like to be able to import a single file that contains the dependencies and logic for modular scale (e.g., `import 'scale/index'`). This matches our JS module pattern (and good modularity in general): self contained and easy to work with.
### TODO

After review, we should bump and release so we can pull into the Rails app.
### Impacted Areas

Modular scale is now loaded as a top-level module in Nightshade-core, and is available through a single import statement. So modular.
### Steps to Reproduce

Everything should work exactly the same.
