### PR TITLE
Add css to tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,7 @@ module.exports = function(config) {
       'node_modules/babel-polyfill/browser.js',
       'node_modules/nunjucks/browser/nunjucks.js',
       'src/**/*.test.js',
+      'src/nightshade.scss',
       'precompiled-templates.js'
     ],
 
@@ -32,7 +33,8 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'src/**/*.test.js': ['browserify']
+      'src/**/*.test.js': ['browserify'],
+      'src/**/*.scss': ['scss']
     },
 
     // Browserify configuration
@@ -105,7 +107,8 @@ module.exports = function(config) {
       'karma-html2js-preprocessor',
       'karma-mocha',
       'karma-mocha-reporter',
-      'karma-phantomjs-launcher'
+      'karma-phantomjs-launcher',
+      'karma-scss-preprocessor'
     ]
   })
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   "dependencies": {
     "@casper/nightshade-icons": "github:caspersleep/nightshade-icons",
     "accoutrement-color": "^1.0.3",
-    "susy": "^2.2.12",
-    "nunjucks": "^2.4.2"
+    "modularscale-sass": "^2.1.1",
+    "nunjucks": "^2.4.2",
+    "susy": "^2.2.12"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "karma-scss-preprocessor": "^2.0.0",
     "lolex": "^1.4.0",
     "mocha": "^2.4.5",
+    "node-sass": "^3.7.0",
     "nodemon": "^1.9.2",
     "phantomjs-prebuilt": "^2.1.7",
     "pre-commit": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "karma-mocha": "^1.0.1",
     "karma-mocha-reporter": "^2.0.3",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-scss-preprocessor": "^2.0.0",
     "lolex": "^1.4.0",
     "mocha": "^2.4.5",
     "nodemon": "^1.9.2",

--- a/src/accordion/Accordion.test.js
+++ b/src/accordion/Accordion.test.js
@@ -50,7 +50,7 @@ describe(`Accordion`, () => {
     const section = document.querySelector(`.js-accordion-section`);
     const sectionContent = document.querySelector(`.js-accordion-section-content`);
 
-    // close the accordion
+    // open the accordion
     Accordion.toggleAccordionSection(section, sectionContent);
 
     setTimeout(() => {
@@ -63,7 +63,7 @@ describe(`Accordion`, () => {
     const section = document.querySelector(`.js-accordion-section`);
     const sectionContent = document.querySelector(`.js-accordion-section-content`);
 
-    // open the accordion
+    // close the accordion
     Accordion.toggleAccordionSection(section, sectionContent);
 
     setTimeout(() => {

--- a/src/accordion/Accordion.test.js
+++ b/src/accordion/Accordion.test.js
@@ -9,14 +9,15 @@ const isHidden = (el) => {
 };
 
 describe(`Accordion`, () => {
-  beforeEach(() => {
+  before(() => {
     const template = nunjucks.render(`accordion/Accordion.test.html`);
 
     document.body.insertAdjacentHTML(`afterbegin`, template);
   });
 
-  afterEach(() => {
+  after(() => {
     const accordion = document.querySelector(`#accordion`);
+
     accordion.parentNode.removeChild(accordion);
   });
 
@@ -33,17 +34,17 @@ describe(`Accordion`, () => {
     assert.equal(Accordion.transitionDuration, 100);
   });
 
-  it(`should initialize with visible sectionContent`, () => {
+  it(`should initialize with hidden sectionContent`, () => {
     Accordion.init(`#accordion`);
 
     const sectionContents = document.querySelectorAll(`.js-accordion-section-content`);
 
-    for (let i = 0; i < sectionContents.length; i++) {
-      assert(!isHidden(sectionContents[i]));
-    }
+    [...sectionContents].forEach((sectionContent) => {
+      assert(isHidden(sectionContent));
+    });
   });
 
-  it(`can toggle accordion section`, (done) => {
+  it(`can open accordion section`, (done) => {
     Accordion.init(`#accordion`, 0);
 
     const section = document.querySelector(`.js-accordion-section`);
@@ -55,7 +56,12 @@ describe(`Accordion`, () => {
     setTimeout(() => {
       assert(!isHidden(sectionContent));
       done();
-    }, 0);
+    }, 50);
+  });
+
+  it(`can close accordion section`, (done) => {
+    const section = document.querySelector(`.js-accordion-section`);
+    const sectionContent = document.querySelector(`.js-accordion-section-content`);
 
     // open the accordion
     Accordion.toggleAccordionSection(section, sectionContent);
@@ -63,6 +69,6 @@ describe(`Accordion`, () => {
     setTimeout(() => {
       assert(isHidden(sectionContent));
       done();
-    }, 0);
+    }, 50);
   });
 });

--- a/src/nightshade.scss
+++ b/src/nightshade.scss
@@ -1,0 +1,4 @@
+@import 'core_imports';
+@import 'base_styles';
+
+@import 'accordion/index';


### PR DESCRIPTION
### Issues

As some functional tests require visuals (i.e. showing/hiding elements), it's beneficial to include the CSS to the test page.

Also, fixed some accordion tests that were inadvertently passing due to lack of CSS.
### Steps to Reproduce

Run `npm install` then `npm test`.
