### PR TITLE
Switch to PhantomJS

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -89,13 +89,18 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome_Sized'],
+    browsers: ['PhantomJS_Sized'],
 
 
     customLaunchers: {
-      'Chrome_Sized': {
-        base: 'Chrome',
-        flags: ['--window-size=400,600']
+      'PhantomJS_Sized': {
+        base: 'PhantomJS',
+        options: {
+          viewportSize: {
+            width: 400,
+            height: 600
+          }
+        }
       }
     },
 

--- a/src/animation/ScrollTo.test.js
+++ b/src/animation/ScrollTo.test.js
@@ -23,6 +23,8 @@ describe(`ScrollTo`, () => {
 
     ScrollTo.scroll({ scrollTarget });
 
+    console.log(`browser height`, window.innerHeight);
+
     setTimeout(() => {
       assert.equal(window.pageYOffset + ScrollTo.offset, initialScrollTargetOffset);
 


### PR DESCRIPTION
### Issues
#136
### Current Status

Right now, config is setup to set PhantomJS viewport settings, but it's not respecting it. You can see in the logging statement that the browser viewport height is 7188px even though the config explicitly set it to 600. You'll see that if you switch it back to Chrome, the viewport height will be correct and the tests will pass.

I used this as a basis: https://github.com/karma-runner/karma/issues/438#issuecomment-65008409
### Todos
- [ ] Get PhantomJS to actually respect viewport settings
### Impacted Areas
- [ ] ScrollTo tests
### Steps to Reproduce
1. Run `npm test`
