### PR TITLE
Refactor Toggler out of Tooltips

### DIFF
--- a/src/nightshade.scss
+++ b/src/nightshade.scss
@@ -4,3 +4,4 @@
 @import 'accordion/index';
 @import 'toggler/index';
 @import 'tooltips/index';
+@import 'popovers/index';

--- a/src/nightshade.scss
+++ b/src/nightshade.scss
@@ -2,4 +2,5 @@
 @import 'base_styles';
 
 @import 'accordion/index';
+@import 'toggler/index';
 @import 'tooltips/index';

--- a/src/popovers/Popovers.js
+++ b/src/popovers/Popovers.js
@@ -1,100 +1,13 @@
 /**
- * @overview A module that initializes and handles Popovers on a page
- * @module Popovers.js
+ * @overview A module that initializes and handles Tooltips on a page
+ * @module Tooltips.js
 */
+import { Toggler } from '../toggler/Toggler.js';
 
-export const Popovers = {
-
-  collapsedClass: `is-invisible`,
-
-  /**
-   * Queries page for Popovers to be initialized, caching them to variables
-   * before calling setup
-   * @param {string} togglerSelector Selector for toggler elements that trigger Popovers
-   * @param {string} popoverSelector Selector for the Popovers to be handled
-   * @returns {void}
-  */
-  popover({togglerSelector, popoverSelector}) {
-    this.togglerEls = document.querySelectorAll(togglerSelector);
-    this.popoverEls = document.querySelectorAll(popoverSelector);
-    this.popoverSelector = popoverSelector;
-    this._setupPopovers();
+const Popovers = Object.assign({}, Toggler, {
+  popover({togglerSelector, popoverSelector }) {
+    this.toggler({togglerSelector, toggleableSelector: popoverSelector});
   },
+});
 
-  /**
-   * Sets up all Popovers on the page, adding event listeners to their togglers
-   * @returns {void}
-   * @private
-  */
-  _setupPopovers() {
-    [...this.togglerEls].forEach((el) => {
-      el.setAttribute(`touch-action`, `none`);
-      el.addEventListener(`pointerup`, (e) => {
-        e.stopPropagation();
-        const popoverEl = el.parentNode.querySelector(this.popoverSelector);
-        this._setupExpandingAndCollapsing(popoverEl);
-      });
-    });
-    this._handleClickOffPopovers();
-  },
-
-  /**
-   * Determines whether to expand (show) or collapse (hide) a given Popover
-   * @param {object} popoverEl Popover DOM element to be expanded or collapsed
-   * @returns {void}
-   * @private
-  */
-  _setupExpandingAndCollapsing(popoverEl) {
-    if (popoverEl.classList.contains(this.collapsedClass)) {
-      this.collapseOpenPopovers();
-      this.expandPopover(popoverEl);
-    } else {
-      this.collapsePopover(popoverEl);
-    }
-  },
-
-  /**
-   * Handles expanding of a given Popover, collapsing any open Popovers first
-   * @param {object} el Popover DOM element to be expanded
-   * @returns {void}
-  */
-  expandPopover(el) {
-    el.setAttribute(`aria-expanded`, true);
-    el.classList.remove(this.collapsedClass);
-  },
-
-  /**
-   * Handles collapsing of a given Popover
-   * @param {object} el Popover DOM element to be collapsed
-   * @returns {void}
-  */
-  collapsePopover(el) {
-    el.setAttribute(`aria-expanded`, false);
-    el.classList.add(this.collapsedClass);
-  },
-
-  /**
-   * Collapses any expanded Popovers on the page
-   * @returns {void}
-  */
-  collapseOpenPopovers() {
-    [...this.popoverEls].forEach((el) => {
-      if (!el.classList.contains(this.collapsedClass)) {
-        this.collapsePopover(el);
-      }
-    });
-  },
-
-  /**
-   * Collapses expanded Popovers on the page when a user clicks outside of them
-   * @returns {void}
-   * @private
-  */
-  _handleClickOffPopovers() {
-    document.addEventListener(`pointerup`, (e) => {
-      if (!e.target.classList.contains(`popover`)) {
-        this.collapseOpenPopovers();
-      }
-    });
-  },
-};
+export { Popovers };

--- a/src/popovers/Popovers.js
+++ b/src/popovers/Popovers.js
@@ -1,6 +1,6 @@
 /**
- * @overview A module that initializes and handles Tooltips on a page
- * @module Tooltips.js
+ * @overview A module that initializes and handles Popovers on a page
+ * @module Popovers.js
 */
 import { Toggler } from '../toggler/Toggler.js';
 

--- a/src/popovers/Popovers.js
+++ b/src/popovers/Popovers.js
@@ -6,7 +6,7 @@ import { Toggler } from '../toggler/Toggler.js';
 
 const Popovers = Object.assign({}, Toggler, {
   popover({togglerSelector, popoverSelector }) {
-    this.toggler({togglerSelector, toggleableSelector: popoverSelector});
+    this.toggler({togglerSelector, toggleableSelector: popoverSelector, eventType: `click`});
   },
 });
 

--- a/src/popovers/Popovers.test.html
+++ b/src/popovers/Popovers.test.html
@@ -1,0 +1,7 @@
+{% from 'popovers/popovers.macros.html' import popover %}
+
+<div id="popovers">
+{% call popover("Test Popover", id="popover") %}Popover Trigger{% endcall %}
+{% call popover("Test Popover 2", id="popover2") %}Popover Trigger{% endcall %}
+{% call popover("Test Popover 3", id="popover3") %}Popover Trigger{% endcall %}
+</div>

--- a/src/popovers/Popovers.test.js
+++ b/src/popovers/Popovers.test.js
@@ -1,32 +1,32 @@
 import assert from 'assert';
 
-import { Tooltips } from './Tooltips';
+import { Popovers } from './Popovers';
 import { Utils } from '../../tests/Utils';
 
 const selectors = {
-  toggler: `.js-tooltip-toggle`,
-  toggleable: `.js-tooltip`,
+  toggler: `.js-popover-toggle`,
+  toggleable: `.js-popover`,
   collapsed: `.is-invisible`,
 };
 
-describe(`Tooltip`, () => {
+describe(`Popover`, () => {
   beforeEach(() => {
-    const template = nunjucks.render(`tooltips/Tooltips.test.html`);
+    const template = nunjucks.render(`popovers/Popovers.test.html`);
 
     document.body.insertAdjacentHTML(`afterbegin`, template);
   });
 
   afterEach(() => {
-    const tooltips = document.querySelector(`#tooltips`);
+    const popovers = document.querySelector(`#popovers`);
 
-    tooltips.parentNode.removeChild(tooltips);
+    popovers.parentNode.removeChild(popovers);
   });
 
-  it(`should initialize with hidden tooltips`, () => {
+  it(`should initialize with hidden popovers`, () => {
     const hiddenToggleable = document.querySelector(selectors.toggleable + selectors.collapsed);
     const hiddenToggler = hiddenToggleable.parentNode.querySelector(selectors.toggler);
 
-    Tooltips.tooltip({ hiddenToggler, hiddenToggleable });
+    Popovers.popover({ hiddenToggler, hiddenToggleable });
 
     assert(Utils.isHidden(hiddenToggleable));
   });

--- a/src/popovers/Popovers.test.js
+++ b/src/popovers/Popovers.test.js
@@ -33,4 +33,16 @@ describe(`Popover`, () => {
       assert(Utils.isHidden(popover));
     });
   });
+
+  it(`should expand on click`, () => {
+    const firstToggler = document.querySelector(selectors.toggler);
+    const firstPopover = firstToggler.parentNode.querySelector(selectors.toggleable);
+
+    Popovers.popover({ togglerSelector: selectors.toggler, popoverSelector: selectors.toggleable });
+
+    // simulate click
+    firstToggler.dispatchEvent(new Event(`pointerup`));
+
+    assert(!Utils.isHidden(firstPopover));
+  });
 });

--- a/src/popovers/Popovers.test.js
+++ b/src/popovers/Popovers.test.js
@@ -23,11 +23,14 @@ describe(`Popover`, () => {
   });
 
   it(`should initialize with hidden popovers`, () => {
-    const hiddenToggleable = document.querySelector(selectors.toggleable + selectors.collapsed);
-    const hiddenToggler = hiddenToggleable.parentNode.querySelector(selectors.toggler);
+    const togglerSelector = selectors.toggler;
+    const popoverSelector = selectors.toggleable;
+    const popovers = document.querySelectorAll(popoverSelector);
 
-    Popovers.popover({ hiddenToggler, hiddenToggleable });
+    Popovers.popover({ togglerSelector, popoverSelector });
 
-    assert(Utils.isHidden(hiddenToggleable));
+    [...popovers].forEach((popover) => {
+      assert(Utils.isHidden(popover));
+    });
   });
 });

--- a/src/toggler/Toggler.js
+++ b/src/toggler/Toggler.js
@@ -64,7 +64,7 @@ export const Toggler = {
   },
 
   /**
-   * Handles expanding of a given Toggler, collapsing any open Togglers first
+   * Handles expanding of a given Toggler
    * @param {object} el Toggleable DOM element to be expanded
    * @returns {void}
   */

--- a/src/toggler/Toggler.js
+++ b/src/toggler/Toggler.js
@@ -11,13 +11,15 @@ export const Toggler = {
    * before calling setup
    * @param {string} togglerSelector Selector for toggler elements that trigger Togglers
    * @param {string} toggleableSelector Selector for the element to be toggled
+   * @param {string} eventType Method of toggling
    * @returns {void}
   */
-  toggler({togglerSelector, toggleableSelector}) {
+  toggler({togglerSelector, toggleableSelector, eventType = `hover`}) {
     this.collapsedClass = `is-invisible`;
     this.togglerEls = document.querySelectorAll(togglerSelector);
     this.toggleableEls = document.querySelectorAll(toggleableSelector);
     this.toggleableSelector = toggleableSelector;
+    this.eventType = eventType;
     this._setupTogglers();
   },
 
@@ -31,7 +33,7 @@ export const Toggler = {
       const toggleableEl = el.parentNode.querySelector(this.toggleableSelector);
       el.setAttribute(`touch-action`, `none`);
 
-      if (feature.touch) {
+      if (this.eventType === `click` || feature.touch) {
         el.addEventListener(`pointerup`, (e) => {
           e.stopPropagation();
           this._setupExpandingAndCollapsing(toggleableEl);

--- a/src/toggler/Toggler.js
+++ b/src/toggler/Toggler.js
@@ -1,0 +1,108 @@
+/**
+ * @overview A module that toggles element visibility
+ * @module Toggler.js
+*/
+
+import feature from 'feature.js';
+
+export const Toggler = {
+  /**
+   * Queries page for Togglers to be initialized, caching them to variables
+   * before calling setup
+   * @param {string} togglerSelector Selector for toggler elements that trigger Togglers
+   * @param {string} toggleableSelector Selector for the element to be toggled
+   * @returns {void}
+  */
+  toggler({togglerSelector, toggleableSelector}) {
+    this.collapsedClass = `is-invisible`;
+    this.togglerEls = document.querySelectorAll(togglerSelector);
+    this.toggleableEls = document.querySelectorAll(toggleableSelector);
+    this.toggleableSelector = toggleableSelector;
+    this._setupTogglers();
+  },
+
+  /**
+   * Sets up all Toggles on the page, adding event listeners to their togglers
+   * @returns {void}
+   * @private
+  */
+  _setupTogglers() {
+    [...this.togglerEls].forEach((el) => {
+      const toggleableEl = el.parentNode.querySelector(this.toggleableSelector);
+      el.setAttribute(`touch-action`, `none`);
+
+      if (feature.touch) {
+        el.addEventListener(`pointerup`, (e) => {
+          e.stopPropagation();
+          this._setupExpandingAndCollapsing(toggleableEl);
+        });
+        this._handleClickOff();
+      } else {
+        el.addEventListener(`pointerenter`, () => {
+          this.expand(toggleableEl);
+        });
+        el.addEventListener(`pointerleave`, () => {
+          this.collapse(toggleableEl);
+        });
+      }
+    });
+  },
+
+  /**
+   * Determines whether to expand (show) or collapse (hide) a given Toggler
+   * @param {object} toggleableEl Toggler DOM element to be expanded or collapsed
+   * @returns {void}
+   * @private
+  */
+  _setupExpandingAndCollapsing(toggleableEl) {
+    if (toggleableEl.classList.contains(this.collapsedClass)) {
+      this.collapseOpen();
+      this.expand(toggleableEl);
+    } else {
+      this.collapse(toggleableEl);
+    }
+  },
+
+  /**
+   * Handles expanding of a given Toggler, collapsing any open Togglers first
+   * @param {object} el Toggleable DOM element to be expanded
+   * @returns {void}
+  */
+  expand(el) {
+    el.setAttribute(`aria-expanded`, true);
+    el.classList.remove(this.collapsedClass);
+  },
+
+  /**
+   * Handles collapsing of a given Toggler
+   * @param {object} el Toggleable DOM element to be collapsed
+   * @returns {void}
+  */
+  collapse(el) {
+    el.setAttribute(`aria-expanded`, false);
+    el.classList.add(this.collapsedClass);
+  },
+
+  /**
+   * Collapses any expanded Togglers on the page
+   * @returns {void}
+  */
+  collapseOpen() {
+    [...this.toggleableEls].forEach((el) => {
+      if (!el.classList.contains(this.collapsedClass)) {
+        this.collapse(el);
+      }
+    });
+  },
+
+  /**
+   * Collapses expanded Togglers on the page when a user clicks outside of them
+   * @returns {void}
+   * @private
+  */
+  _handleClickOff() {
+    document.addEventListener(`pointerup`, () => {
+      this.collapseOpen();
+    });
+  },
+};

--- a/src/toggler/Toggler.test.html
+++ b/src/toggler/Toggler.test.html
@@ -1,0 +1,10 @@
+<div id="toggler">
+  <span class="toggler-container js-toggler-container">
+    <span class="toggler js-toggler">Toggler</span>
+    <span class="toggleable js-toggleable is-invisible" aria-expanded="false">This is toggleable</span>
+  </span>
+  <span class="toggler-container js-toggler-container">
+    <span class="toggler js-toggler">Toggler</span>
+    <span class="toggleable js-toggleable" aria-expanded="true">This is toggleable</span>
+  </span>
+</div>

--- a/src/toggler/Toggler.test.js
+++ b/src/toggler/Toggler.test.js
@@ -1,0 +1,86 @@
+import assert from 'assert';
+
+import { Tooltips } from '../tooltips/Tooltips';
+import { Popovers } from '../popovers/Popovers';
+
+const togglerPluginNames = [ `Tooltips`, `Popovers` ];
+
+const isHidden = (el) => {
+  const style = window.getComputedStyle(el);
+
+  return (style.display === `none` || style.visibility === `hidden`);
+};
+
+[...togglerPluginNames].forEach((togglerPluginName) => {
+  const Plugin = eval(togglerPluginName);
+  const plugin = {
+    dir: togglerPlugin.toLowerCase(),
+    id: togglerPlugin.toLowerCase(),
+    name: togglerPlugin,
+    class: togglerPlugin.toLowerCase().replace(/s$/, ``),
+  };
+
+  describe(togglerPlugin, () => {
+    beforeEach(() => {
+      const template = nunjucks.render(`${plugin.dir}/${plugin.name}.test.html`);
+
+      document.body.insertAdjacentHTML(`afterbegin`, template);
+    });
+
+    afterEach(() => {
+      const togglers = document.querySelector(`#${plugin.id}`);
+
+      togglers.parentNode.removeChild(togglers);
+    });
+
+    it(`should initialize with hidden ${plugin.name}`, () => {
+      const togglerSelector = `.js-${plugin.class}-toggle`;
+      const toggleableSelector = `.js-${plugin.class}`;
+      const toggleables = document.querySelectorAll(toggleableSelector);
+
+      Plugin.tooltip({ togglerSelector, toggleableSelector });
+
+      [...toggleables].forEach((toggleable) => {
+        assert(isHidden(toggleable));
+      });
+    });
+
+    it(`should be visible after expanding`, () => {
+      const tooltip = document.querySelector(`.js-tooltip`);
+
+      Tooltips.expand(tooltip);
+
+      assert(!isHidden(tooltip));
+    });
+
+    it(`should be hidden after closing`, () => {
+      const tooltip = document.querySelector(`.js-tooltip`);
+
+      Tooltips.expand(tooltip);
+      Tooltips.collapse(tooltip);
+
+      assert(isHidden(tooltip));
+    });
+
+    it(`should collapse all tooltips`, () => {
+      const togglerSelector = `.js-tooltip-toggle`;
+      const tooltipSelector = `.js-tooltip`;
+      const tooltips = document.querySelectorAll(tooltipSelector);
+
+      Tooltips.tooltip({ togglerSelector, tooltipSelector });
+
+      // expand all the tooltips
+      [...tooltips].forEach((tooltip) => {
+        Tooltips.expand(tooltip);
+      });
+
+      // collapse all the tooltips
+      Tooltips.collapseOpen();
+
+      // check that they're closed
+      [...tooltips].forEach((tooltip) => {
+        assert(isHidden(tooltip));
+      });
+    });
+  });
+});

--- a/src/toggler/Toggler.test.js
+++ b/src/toggler/Toggler.test.js
@@ -1,12 +1,7 @@
 import assert from 'assert';
 
 import { Toggler } from './Toggler';
-
-const isHidden = (el) => {
-  const style = window.getComputedStyle(el);
-
-  return (style.display === `none` || style.visibility === `hidden`);
-};
+import { Utils } from '../../tests/Utils';
 
 const selectors = {
   toggler: `.js-toggler`,
@@ -33,7 +28,7 @@ describe(`Toggler`, () => {
 
     Toggler.toggler({ hiddenToggler, hiddenToggleable });
 
-    assert(isHidden(hiddenToggleable));
+    assert(Utils.isHidden(hiddenToggleable));
   });
 
   it(`can initialize with visible Toggler`, () => {
@@ -42,7 +37,7 @@ describe(`Toggler`, () => {
 
     Toggler.toggler({ visibleToggler, visibleToggleable });
 
-    assert(!isHidden(visibleToggleable));
+    assert(!Utils.isHidden(visibleToggleable));
   });
 
   it(`should be visible after expanding`, () => {
@@ -50,7 +45,7 @@ describe(`Toggler`, () => {
 
     Toggler.expand(toggleable);
 
-    assert(!isHidden(toggleable));
+    assert(!Utils.isHidden(toggleable));
   });
 
   it(`should be hidden after closing`, () => {
@@ -59,7 +54,7 @@ describe(`Toggler`, () => {
     Toggler.expand(toggleable);
     Toggler.collapse(toggleable);
 
-    assert(isHidden(toggleable));
+    assert(Utils.isHidden(toggleable));
   });
 
   it(`should collapse all tooltips`, () => {
@@ -79,7 +74,7 @@ describe(`Toggler`, () => {
 
     // check that they're closed
     [...toggleables].forEach((toggleable) => {
-      assert(isHidden(toggleable));
+      assert(Utils.isHidden(toggleable));
     });
   });
 });

--- a/src/toggler/Toggler.test.js
+++ b/src/toggler/Toggler.test.js
@@ -1,9 +1,6 @@
 import assert from 'assert';
 
-import { Tooltips } from '../tooltips/Tooltips';
-import { Popovers } from '../popovers/Popovers';
-
-const togglerPluginNames = [ `Tooltips`, `Popovers` ];
+import { Toggler } from './Toggler';
 
 const isHidden = (el) => {
   const style = window.getComputedStyle(el);
@@ -11,76 +8,78 @@ const isHidden = (el) => {
   return (style.display === `none` || style.visibility === `hidden`);
 };
 
-[...togglerPluginNames].forEach((togglerPluginName) => {
-  const Plugin = eval(togglerPluginName);
-  const plugin = {
-    dir: togglerPlugin.toLowerCase(),
-    id: togglerPlugin.toLowerCase(),
-    name: togglerPlugin,
-    class: togglerPlugin.toLowerCase().replace(/s$/, ``),
-  };
+const selectors = {
+  toggler: `.js-toggler`,
+  toggleable: `.js-toggleable`,
+  collapsed: `.is-invisible`,
+};
 
-  describe(togglerPlugin, () => {
-    beforeEach(() => {
-      const template = nunjucks.render(`${plugin.dir}/${plugin.name}.test.html`);
+describe(`Toggler`, () => {
+  beforeEach(() => {
+    const template = nunjucks.render(`toggler/Toggler.test.html`);
 
-      document.body.insertAdjacentHTML(`afterbegin`, template);
+    document.body.insertAdjacentHTML(`afterbegin`, template);
+  });
+
+  afterEach(() => {
+    const togglers = document.querySelector(`#toggler`);
+
+    togglers.parentNode.removeChild(togglers);
+  });
+
+  it(`can initialize with hidden Toggler`, () => {
+    const hiddenToggleable = document.querySelector(selectors.toggleable + selectors.collapsed);
+    const hiddenToggler = hiddenToggleable.parentNode.querySelector(selectors.toggler);
+
+    Toggler.toggler({ hiddenToggler, hiddenToggleable });
+
+    assert(isHidden(hiddenToggleable));
+  });
+
+  it(`can initialize with visible Toggler`, () => {
+    const visibleToggleable = document.querySelector(selectors.toggleable + `:not(${selectors.collapsed})`);
+    const visibleToggler = visibleToggleable.parentNode.querySelector(selectors.toggler);
+
+    Toggler.toggler({ visibleToggler, visibleToggleable });
+
+    assert(!isHidden(visibleToggleable));
+  });
+
+  it(`should be visible after expanding`, () => {
+    const toggleable = document.querySelector(selectors.toggleable);
+
+    Toggler.expand(toggleable);
+
+    assert(!isHidden(toggleable));
+  });
+
+  it(`should be hidden after closing`, () => {
+    const toggleable = document.querySelector(selectors.toggleable);
+
+    Toggler.expand(toggleable);
+    Toggler.collapse(toggleable);
+
+    assert(isHidden(toggleable));
+  });
+
+  it(`should collapse all tooltips`, () => {
+    const toggleables = document.querySelectorAll(selectors.toggleable);
+    const togglerSelector = selectors.toggler;
+    const toggleableSelector = selectors.toggleable;
+
+    Toggler.toggler({ togglerSelector, toggleableSelector });
+
+    // expand all the toggleables
+    [...toggleables].forEach((toggleable) => {
+      Toggler.expand(toggleable);
     });
 
-    afterEach(() => {
-      const togglers = document.querySelector(`#${plugin.id}`);
+    // collapse all the tooltips
+    Toggler.collapseOpen();
 
-      togglers.parentNode.removeChild(togglers);
-    });
-
-    it(`should initialize with hidden ${plugin.name}`, () => {
-      const togglerSelector = `.js-${plugin.class}-toggle`;
-      const toggleableSelector = `.js-${plugin.class}`;
-      const toggleables = document.querySelectorAll(toggleableSelector);
-
-      Plugin.tooltip({ togglerSelector, toggleableSelector });
-
-      [...toggleables].forEach((toggleable) => {
-        assert(isHidden(toggleable));
-      });
-    });
-
-    it(`should be visible after expanding`, () => {
-      const tooltip = document.querySelector(`.js-tooltip`);
-
-      Tooltips.expand(tooltip);
-
-      assert(!isHidden(tooltip));
-    });
-
-    it(`should be hidden after closing`, () => {
-      const tooltip = document.querySelector(`.js-tooltip`);
-
-      Tooltips.expand(tooltip);
-      Tooltips.collapse(tooltip);
-
-      assert(isHidden(tooltip));
-    });
-
-    it(`should collapse all tooltips`, () => {
-      const togglerSelector = `.js-tooltip-toggle`;
-      const tooltipSelector = `.js-tooltip`;
-      const tooltips = document.querySelectorAll(tooltipSelector);
-
-      Tooltips.tooltip({ togglerSelector, tooltipSelector });
-
-      // expand all the tooltips
-      [...tooltips].forEach((tooltip) => {
-        Tooltips.expand(tooltip);
-      });
-
-      // collapse all the tooltips
-      Tooltips.collapseOpen();
-
-      // check that they're closed
-      [...tooltips].forEach((tooltip) => {
-        assert(isHidden(tooltip));
-      });
+    // check that they're closed
+    [...toggleables].forEach((toggleable) => {
+      assert(isHidden(toggleable));
     });
   });
 });

--- a/src/toggler/Toggler.test.js
+++ b/src/toggler/Toggler.test.js
@@ -23,19 +23,21 @@ describe(`Toggler`, () => {
   });
 
   it(`can initialize with hidden Toggler`, () => {
-    const hiddenToggleable = document.querySelector(selectors.toggleable + selectors.collapsed);
-    const hiddenToggler = hiddenToggleable.parentNode.querySelector(selectors.toggler);
+    const togglerSelector = selectors.toggler;
+    const toggleableSelector = selectors.toggleable + selectors.collapsed;
+    const hiddenToggleable = document.querySelector(toggleableSelector);
 
-    Toggler.toggler({ hiddenToggler, hiddenToggleable });
+    Toggler.toggler({ togglerSelector, toggleableSelector });
 
     assert(Utils.isHidden(hiddenToggleable));
   });
 
   it(`can initialize with visible Toggler`, () => {
-    const visibleToggleable = document.querySelector(selectors.toggleable + `:not(${selectors.collapsed})`);
-    const visibleToggler = visibleToggleable.parentNode.querySelector(selectors.toggler);
+    const togglerSelector = selectors.toggler;
+    const toggleableSelector = selectors.toggleable + `:not(${selectors.collapsed})`;
+    const visibleToggleable = document.querySelector(toggleableSelector);
 
-    Toggler.toggler({ visibleToggler, visibleToggleable });
+    Toggler.toggler({ togglerSelector, toggleableSelector });
 
     assert(!Utils.isHidden(visibleToggleable));
   });

--- a/src/toggler/_base.scss
+++ b/src/toggler/_base.scss
@@ -1,0 +1,5 @@
+.toggleable {
+  &.is-invisible {
+    display: none;
+  }
+}

--- a/src/toggler/_index.scss
+++ b/src/toggler/_index.scss
@@ -1,0 +1,1 @@
+@import 'base';

--- a/src/tooltips/Tooltips.js
+++ b/src/tooltips/Tooltips.js
@@ -6,7 +6,7 @@ import { Toggler } from '../toggler/Toggler.js';
 
 const Tooltips = Object.assign({}, Toggler, {
   tooltip({togglerSelector, tooltipSelector }) {
-    this.toggler({togglerSelector, toggleableSelector: tooltipSelector});
+    this.toggler({togglerSelector, toggleableSelector: tooltipSelector, eventType: `hover`});
   },
 });
 

--- a/src/tooltips/Tooltips.js
+++ b/src/tooltips/Tooltips.js
@@ -2,109 +2,12 @@
  * @overview A module that initializes and handles Tooltips on a page
  * @module Tooltips.js
 */
+import { Toggler } from '../toggler/Toggler.js';
 
-import feature from 'feature.js';
-
-export const Tooltips = {
-
-  collapsedClass: `is-invisible`,
-
-  /**
-   * Queries page for Tooltips to be initialized, caching them to variables
-   * before calling setup
-   * @param {string} togglerSelector Selector for toggler elements that trigger Tooltips
-   * @param {string} tooltipSelector Selector for the Tooltips to be handled
-   * @returns {void}
-  */
-  tooltip({togglerSelector, tooltipSelector}) {
-    this.togglerEls = document.querySelectorAll(togglerSelector);
-    this.tooltipEls = document.querySelectorAll(tooltipSelector);
-    this.tooltipSelector = tooltipSelector;
-    this._setupTooltips();
+const Tooltips = Object.assign({}, Toggler, {
+  tooltip({togglerSelector, tooltipSelector }) {
+    this.toggler({togglerSelector, toggleableSelector: tooltipSelector});
   },
+});
 
-  /**
-   * Sets up all Tooltips on the page, adding listeners to their togglers
-   * @returns {void}
-   * @private
-  */
-  _setupTooltips() {
-    [...this.togglerEls].forEach((el) => {
-      const tooltipEl = el.parentNode.querySelector(this.tooltipSelector);
-      el.setAttribute(`touch-action`, `none`);
-
-      if (feature.touch) {
-        el.addEventListener(`pointerup`, (e) => {
-          e.stopPropagation();
-          this._setupExpandingAndCollapsing(tooltipEl);
-        });
-        this._handleClickOffTooltips();
-      } else {
-        el.addEventListener(`pointerenter`, () => {
-          this.expandTooltip(tooltipEl);
-        });
-        el.addEventListener(`pointerleave`, () => {
-          this.collapseTooltip(tooltipEl);
-        });
-      }
-    });
-  },
-
-  /**
-   * Determines whether to expand (show) or collapse (hide) a given Tooltip
-   * @param {object} tooltipEl Tooltip DOM element to be expanded or collapsed
-   * @returns {void}
-   * @private
-  */
-  _setupExpandingAndCollapsing(tooltipEl) {
-    if (tooltipEl.classList.contains(this.collapsedClass)) {
-      this.collapseOpenTooltips();
-      this.expandTooltip(tooltipEl);
-    } else {
-      this.collapseTooltip(tooltipEl);
-    }
-  },
-
-  /**
-   * Handles expanding of a given Tooltip
-   * @param {object} el Tooltip DOM element to be expanded
-   * @returns {void}
-  */
-  expandTooltip(el) {
-    el.setAttribute(`aria-expanded`, true);
-    el.classList.remove(this.collapsedClass);
-  },
-
-  /**
-   * Handles collapsing of a given Tooltip
-   * @param {object} el Tooltip DOM element to be collapsed
-   * @returns {void}
-  */
-  collapseTooltip(el) {
-    el.setAttribute(`aria-expanded`, false);
-    el.classList.add(this.collapsedClass);
-  },
-
-  /**
-   * Collapses any expanded Tooltips on the page
-   * @returns {void}
-  */
-  collapseOpenTooltips() {
-    [...this.tooltipEls].forEach((el) => {
-      if (!el.classList.contains(this.collapsedClass)) {
-        this.collapseTooltip(el);
-      }
-    });
-  },
-
-  /**
-   * Collapses expanded Tooltips on the page when a user clicks outside of them
-   * @returns {void}
-   * @private
-  */
-  _handleClickOffTooltips() {
-    document.addEventListener(`pointerup`, () => {
-      this.collapseOpenTooltips();
-    });
-  },
-};
+export { Tooltips };

--- a/src/tooltips/Tooltips.test.js
+++ b/src/tooltips/Tooltips.test.js
@@ -34,7 +34,7 @@ describe(`Tooltip`, () => {
     });
   });
 
-  it(`should expand on click`, () => {
+  it(`should expand on hover`, () => {
     const firstToggler = document.querySelector(selectors.toggler);
     const firstTooltip = firstToggler.parentNode.querySelector(selectors.toggleable);
 

--- a/src/tooltips/Tooltips.test.js
+++ b/src/tooltips/Tooltips.test.js
@@ -36,7 +36,7 @@ describe(`Tooltip`, () => {
   it(`should be visible after expanding`, () => {
     const tooltip = document.querySelector(`.js-tooltip`);
 
-    Tooltips.expandTooltip(tooltip);
+    Tooltips.expand(tooltip);
 
     assert(!isHidden(tooltip));
   });
@@ -44,8 +44,8 @@ describe(`Tooltip`, () => {
   it(`should be hidden after closing`, () => {
     const tooltip = document.querySelector(`.js-tooltip`);
 
-    Tooltips.expandTooltip(tooltip);
-    Tooltips.collapseTooltip(tooltip);
+    Tooltips.expand(tooltip);
+    Tooltips.collapse(tooltip);
 
     assert(isHidden(tooltip));
   });
@@ -59,11 +59,11 @@ describe(`Tooltip`, () => {
 
     // expand all the tooltips
     [...tooltips].forEach((tooltip) => {
-      Tooltips.expandTooltip(tooltip);
+      Tooltips.expand(tooltip);
     });
 
     // collapse all the tooltips
-    Tooltips.collapseOpenTooltips();
+    Tooltips.collapseOpen();
 
     // check that they're closed
     [...tooltips].forEach((tooltip) => {

--- a/src/tooltips/Tooltips.test.js
+++ b/src/tooltips/Tooltips.test.js
@@ -23,11 +23,14 @@ describe(`Tooltip`, () => {
   });
 
   it(`should initialize with hidden tooltips`, () => {
-    const hiddenToggleable = document.querySelector(selectors.toggleable + selectors.collapsed);
-    const hiddenToggler = hiddenToggleable.parentNode.querySelector(selectors.toggler);
+    const togglerSelector = selectors.toggler;
+    const tooltipSelector = selectors.toggleable;
+    const tooltips = document.querySelectorAll(tooltipSelector);
 
-    Tooltips.tooltip({ hiddenToggler, hiddenToggleable });
+    Tooltips.tooltip({ togglerSelector, tooltipSelector });
 
-    assert(Utils.isHidden(hiddenToggleable));
+    [...tooltips].forEach((tooltip) => {
+      assert(Utils.isHidden(tooltip));
+    });
   });
 });

--- a/src/tooltips/Tooltips.test.js
+++ b/src/tooltips/Tooltips.test.js
@@ -33,4 +33,16 @@ describe(`Tooltip`, () => {
       assert(Utils.isHidden(tooltip));
     });
   });
+
+  it(`should expand on click`, () => {
+    const firstToggler = document.querySelector(selectors.toggler);
+    const firstTooltip = firstToggler.parentNode.querySelector(selectors.toggleable);
+
+    Tooltips.tooltip({ togglerSelector: selectors.toggler, tooltipSelector: selectors.toggleable });
+
+    // simulate click
+    firstToggler.dispatchEvent(new Event(`pointerenter`));
+
+    assert(!Utils.isHidden(firstTooltip));
+  });
 });

--- a/tests/Utils.js
+++ b/tests/Utils.js
@@ -1,0 +1,9 @@
+const isHidden = (el) => {
+  const style = window.getComputedStyle(el);
+
+  return (style.display === `none` || style.visibility === `hidden`);
+};
+
+export const Utils = {
+  isHidden,
+};


### PR DESCRIPTION
### Issues
#99

The Tooltip and Popover patterns are almost identical. I've pulled out most of it into a Toggler pattern - Tooltip is now inheriting from Tooltip.
### Impacted Areas

Tooltip and Popover patterns
### Steps to Reproduce
1. Run `npm install` and the tests should still pass.
2. Link `nightshade-core` within `nightshade` and make sure the patterns still work.
