### PR TITLE
Allow header/footer take a different phone number

### DIFF
--- a/src/footer/footer.macros.html
+++ b/src/footer/footer.macros.html
@@ -7,7 +7,7 @@
 {#
   * Renders a standard or simplified footer
 #}
-{% macro footer(simple=false, class=null, id=null) %}
+{% macro footer(simple=false, class=null, id=null, phone_number='888–498–0003') %}
 <footer class="footer{% if simple %} footer--simple{% endif %}{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
   <div class="footer-top r-inner">
     {{ caller() }}
@@ -42,9 +42,9 @@
 
       {% if not simple %}
       <div class="footer-nav-group footer-nav-group--right">
-        <a class="footer-nav-group-link footer-nav-group-link--contact footer-nav-group-link--contact-phone" href="tel:18884980003">
+        <a class="footer-nav-group-link footer-nav-group-link--contact footer-nav-group-link--contact-phone" href="tel:1{{ phone_number|replace('-', '') }}">
           {{ icon('phone', size='x-small') }}
-          <span class="footer-nav-group-text--bottom footer-nav-group-text--contact">888–498–0003</span>
+          <span class="footer-nav-group-text--bottom footer-nav-group-text--contact">{{ phone_number }}</span>
         </a>
         <a target="_blank" class="footer-nav-group-link footer-nav-group-link--contact" href="/help">
           {{ icon('envelope') }}

--- a/src/layout/regions.macros.html
+++ b/src/layout/regions.macros.html
@@ -173,7 +173,7 @@
 </nav>
 {% endmacro %}
 
-{% macro header(simple=false, fixed=true) %}
+{% macro header(simple=false, fixed=true, phone_number='888–498–0003') %}
 <header id="header" class="r-header{% if simple %} r-header--simple{% endif %}{% if not fixed %} r-header--static{% endif %}" role="banner">
   <div class="header-wrapper">
     <nav class="js-nav-main nav-main nav-main--primary">
@@ -184,9 +184,9 @@
       <ul class="nav-main-group nav-main-group--user">
         <li role="presentation">
           <span class="phone-number js-a-sup-phone">
-            <a class="nav-item" data-track-click-target="phone" href="tel:18884980003">
+            <a class="nav-item" data-track-click-target="phone" href="tel:1{{ phone_number|replace('-', '') }}">
               {{ icon.icon("phone")}}
-              888–498–0003
+              {{ phone_number }}
             </a>
           </span>
         </li>


### PR DESCRIPTION
Allows the simple header to take a different phone number, but keeps the current number as the default number
