### PR TITLE
Add class to list item in macro

### DIFF
--- a/src/lists/lists.macros.html
+++ b/src/lists/lists.macros.html
@@ -23,11 +23,11 @@
   <ul class="list-items">
   {% for item in data.list %}
     {% if action_link and loop.last %}
-    <li>
+    <li class="list-item">
       {{ link_icon(item.content, href=item.href, icon=action_link_icon, icon_size=icon_size) }}
     </li>
     {% else %}
-    <li>
+    <li class="list-item">
       {{ link(item.content, href=item.href) }}
     </li>
     {% endif %}


### PR DESCRIPTION
### Issues

The list item was not getting a class within the lists macro 
### Todos

Update store front static and other pages the use the list
### Impacted Areas

Store front static and other pages that use the list
### Steps to Reproduce

Run nightshade with this branch, check that items in the list are getting a class 'list-item'
