### PR TITLE
Add normalize.scss as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@casper/nightshade-icons": "github:caspersleep/nightshade-icons",
     "accoutrement-color": "^1.0.3",
     "modularscale-sass": "^2.1.1",
+    "normalize.scss": "github:caspersleep/normalize.scss",
     "nunjucks": "^2.4.2",
     "susy": "^2.2.12"
   },

--- a/src/_base_styles.scss
+++ b/src/_base_styles.scss
@@ -3,6 +3,9 @@
  * @overview Site scaffolding and helper classes that generate output
  */
 
+// Third party
+@import './node_modules/normalize.scss/normalize';
+
 @import 'typography/index';
 @import 'layout/grids';
 @import 'animation/custom_animations';

--- a/src/_base_styles.scss
+++ b/src/_base_styles.scss
@@ -3,9 +3,12 @@
  * @overview Site scaffolding and helper classes that generate output
  */
 
-// Third party
+// Third party dependency that needs to load immediately after _core_imports
 @import './node_modules/normalize.scss/normalize';
 
+// Ordered imports
+// @todo See about alphabetizing/extending comments to include more information
+// on why each partial appears in said order
 @import 'typography/index';
 @import 'layout/grids';
 @import 'animation/custom_animations';

--- a/src/_base_styles.scss
+++ b/src/_base_styles.scss
@@ -3,12 +3,8 @@
  * @overview Site scaffolding and helper classes that generate output
  */
 
-// Third party dependency that needs to load immediately after _core_imports
 @import './node_modules/normalize.scss/normalize';
 
-// Ordered imports
-// @todo See about alphabetizing/extending comments to include more information
-// on why each partial appears in said order
 @import 'typography/index';
 @import 'layout/grids';
 @import 'animation/custom_animations';


### PR DESCRIPTION
This PR adds normalize.scss as dependency and imports the partial at the top of `base_styles.scss`.
