### PR TITLE
Remove H1 top margin added by normalize.scss

### DIFF
--- a/src/phantom/base/_typography.scss
+++ b/src/phantom/base/_typography.scss
@@ -74,6 +74,7 @@ $headings: "h1, .h1, h2, .h2, h3, .h3, h4, .h4";
 h1,
 .h1 {
   @extend %h1;
+  margin-top: 0;
 }
 
 

--- a/src/typography/_base.scss
+++ b/src/typography/_base.scss
@@ -94,6 +94,7 @@ $headings: "h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6";
 h1,
 .h1 {
   @extend %h1;
+  margin-top: 0;
 }
 
 


### PR DESCRIPTION
This is a patch that will update to v2.5.1, fixing an issue where the latest version of normalize.css adds top margins to H1 elements.
