### PR TITLE
Un-interpolate return value of size function

### DIFF
--- a/src/phantom/base/_sizing_config.scss
+++ b/src/phantom/base/_sizing_config.scss
@@ -60,5 +60,5 @@ $sizing: (
 
   $size: map-get($sizing, $size) or $size;
 
-  @return #{$size};
+  @return $size;
 }


### PR DESCRIPTION
### Issues

The `size` function returns a string, which makes it difficult to do math in Sass. I'm un-interpolating the return value so that you can do things like this now:

`size(largest) * -1`
### Steps to Reproduce
1. Run `npm link` in `nightshade-core`.
2. Run `npm link @casper/nightshade-core` in Casper Rails.
3. Make sure that the above syntax works, and that the `size` function is returning correctly.
