### PR TITLE
Use project-local eslint instead of globally installed eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.2",
   "description": "Casper pattern and style scss library. Under development.",
   "scripts": {
-    "eslint": "eslint src",
+    "eslint": "./node_modules/.bin/eslint src",
     "test": "./node_modules/.bin/nunjucks-precompile src > precompiled-templates.js && ./node_modules/karma/bin/karma start karma.conf.js",
     "postversion": "git push && git push --tags"
   },


### PR DESCRIPTION
### Issues

Currently, if you don't have `eslint` globally installed, then `npm run eslint` fails. More seriously, committing to Git fails because of the `eslint` pre-commit hook.

Since `eslint` is a devdep, we're now pointing at the project-local `eslint` instead of the global one. This ensures that it will always work no matter what version of Node you happen to be using.
### Steps to Reproduce

Run `npm run eslint` without a globally-installed `eslint` and it should work!
