### PR TITLE
Use arrow-down in accordion

### DIFF
--- a/src/accordion/_base.scss
+++ b/src/accordion/_base.scss
@@ -33,13 +33,12 @@
     padding: ms(3) 0 ms(2);
   }
 
-  [data-icon="arrow"] {
+  [data-icon="arrow-down"] {
     align-self: auto;
     fill: currentColor;
-    transform: rotate(90deg);
 
     .is-accordion-open & {
-      transform: rotate(270deg);
+      transform: rotate(180deg);
     }
   }
 }


### PR DESCRIPTION
### Issues

The arrow icon was being used instead of the arrow-down icon.  This PR replaces the arrow with the correct one and adjusts the styling accordingly.
### Todos

None.
### Impacted Areas

The accordion module in nightshade and in the Casper Rails repo.
### Steps to Reproduce

None.
