### PR TITLE
Hotfix compile errors: Missing icons.macros.html

### DIFF
--- a/src/accordion/accordion.macros.html
+++ b/src/accordion/accordion.macros.html
@@ -4,8 +4,8 @@
   *
 #}
 
-{% from 'icons/icons.macros.html' import icon %}
-{% from 'links/links.macros.html' import link %}
+{% from '../icons/icons.macros.html' import icon %}
+{% from '../links/links.macros.html' import link %}
 
 {#
   * Renders a special list for content within accordions

--- a/src/icons/icons.macros.html
+++ b/src/icons/icons.macros.html
@@ -1,9 +1,25 @@
+{#
+  * @overview Macros for SVG icons.
+  * @module Icons
+  * @todo: Add examples of icon_class and icon sizes
+#}
+
+{#
+  * Renders an icon with use method. Used for uniquely sized icons.
+  * @param {string} name - Name of the icon (nightshade.rocks/icons)
+  * @param {string} [icon_class=true] - Class name for style or JS targeting
+#}
 {% macro svg(name, icon_class=true) %}
 <svg class="icon{% if icon_class %} icon-{{ name }}{% endif %}" aria-labelledby="title" role="img">
   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{ name }}"></use>
 </svg>
 {% endmacro %}
 
+{#
+  * Renders an icon using set sizes
+  * @param {string} name - Name of the icon (nightshade.rocks/icons)
+  * @param {string} [size=default] - Size of the icon from preset values
+#}
 {% macro icon(name, size="default") %}
   <span data-icon="{{ name }}" data-size="{{ size }}">
     {{ svg(name, false) }}

--- a/src/links/links.macros.html
+++ b/src/links/links.macros.html
@@ -5,7 +5,7 @@
   * @todo Consider moving this to typography when we revise type
 #}
 
-{% from 'icons/icons.macros.html' import icon as icon_macro %}
+{% from '../icons/icons.macros.html' import icon as icon_macro %}
 
 {#
   * Renders a link

--- a/src/lists/lists.macros.html
+++ b/src/lists/lists.macros.html
@@ -4,7 +4,7 @@
   * @TODO rename to list-heading
 #}
 
-{% from 'nightshade-core/src/links/links.macros.html' import link, link_icon %}
+{% from '../links/links.macros.html' import link, link_icon %}
 
 {#
   * Renders a List of links


### PR DESCRIPTION
Imports need to be defined relative to nightshade-core/src in order to
avoid errors. This resolves errors when running storefront-static or
nightshade
## Test
1. Setup link to nightshade-core#hotfix-missing-tpls
2. Open `storefront-static` or `nigthshade`
3. Run `gulp compile`. Should compile without errors.
