### PR TITLE
Fix flexbox issues on IE11

### DIFF
--- a/src/banners/_cta_banner.scss
+++ b/src/banners/_cta_banner.scss
@@ -10,7 +10,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: ms(16);
+  height: ms(16);
   padding: ms(8) ms(2);
   background-repeat: no-repeat;
   background-size: cover;

--- a/src/blocks/_base.scss
+++ b/src/blocks/_base.scss
@@ -40,6 +40,7 @@
 .block-item-image {
   margin-bottom: ms(2);
   fill: color(primary);
+  flex-shrink: 0; // Fix for IE10-11
 
   .icon {
     @include square(100%);
@@ -48,4 +49,8 @@
 
 .block-item-heading {
   max-width: 14em;
+}
+
+.block-item-body {
+  width: 100%; // Fix for IE10-11
 }

--- a/src/content_panel/_base.scss
+++ b/src/content_panel/_base.scss
@@ -59,6 +59,7 @@
 }
 
 .content-panel-content-body {
+  width: 100%;
   max-width: 22em;
   font-size: ms(1);
   text-align: center;

--- a/src/trial_returns/_base.scss
+++ b/src/trial_returns/_base.scss
@@ -30,6 +30,7 @@
     top: 0;
     left: 0;
     right: 0;
+    width: 100%;
   }
 
   .icon,
@@ -69,6 +70,10 @@
   @include respond-at-and-above($break-large) {
     max-width: 32em;
   }
+}
+
+.trial-returns-image {
+  flex-shrink: 0; // Fix for IE10-11
 }
 
 // Styles for longer text languages


### PR DESCRIPTION
This PR integrates some fixes for several modules on the PDPs in ie11
- trial warranty image on /sheets
- trial warranty text being off center on /mattress and /pillows
- infographic spacing
- cta video banner height

To test:  checkout out this branch and npm link
