### PR TITLE
Letter spacing for items that reply on phantom styles

### DIFF
--- a/src/phantom/base/_base.scss
+++ b/src/phantom/base/_base.scss
@@ -47,6 +47,7 @@ html {
 
 body {
   @extend %verlag-light;
+  letter-spacing: 0.04rem;
   margin: 0 auto;
   width: 100%;
 }


### PR DESCRIPTION
Give the verlag body copy a base letter spacing.  This helps avoid some design gaps while migrating things over off of phantom styles.
