### PR TITLE
Make heading-1 size down below break-medium

### DIFF
--- a/src/trial_returns/_base.scss
+++ b/src/trial_returns/_base.scss
@@ -47,15 +47,14 @@
 
 .trial-returns-heading {
   max-width: 12em;
-  font-size: ms(1);
   color: color(primary);
 
   @include respond-at-and-above($break-small) {
     max-width: 20em;
   }
 
-  @include respond-at-and-above($break-medium) {
-    font-size: ms(4);
+  @include respond-below($break-medium - 1) {
+    font-size: ms(1);
   }
 }
 

--- a/src/typography/_headings_config.scss
+++ b/src/typography/_headings_config.scss
@@ -7,9 +7,13 @@
 
 @mixin heading-1 {
   @include heading;
-  font-size: ms(4);
+  font-size: ms(3);
   margin-bottom: ms(1);
   letter-spacing: size(small-tracking);
+
+  @include respond-at-and-above($break-medium) {
+    font-size: ms(4);
+  }
 }
 
 @mixin heading-2 {


### PR DESCRIPTION
A PR against Casper repo will be tied to this to remove any CSS one-offs for heading-1 instances on the Storefront
