### PR TITLE
Add styling changes for required fields change.

### DIFF
--- a/src/forms/_base.scss
+++ b/src/forms/_base.scss
@@ -202,36 +202,34 @@ select {
   &.has-text {
 
     .form-label {
-      transform: translateY(0);
-      opacity: 1;
+      transform: translateY(0.45rem) scale(0.8);
       pointer-events: auto;
     }
 
     .form-input {
       padding: 1.3rem ms(0) 0.4rem;
     }
-
-    .form-input--select {
-      color: color(text);
-    }
   }
 
   .form-label {
     position: absolute;
-    top: ms(-4);
-    left: 1.1rem;
-    font-size: ms(-1);
+    top: 0;
+    font-size: ms(0);
     letter-spacing: size(smaller-tracking);
     line-height: 1;
     color: color(dark-text);
-    opacity: 0;
     pointer-events: none;
-    transform: translateY(ms(-9));
-    transition: transform 0.25s ease-out, opacity 0.25s ease-out;
+    transform: translateY(1rem) scale(1);
+    transition: transform 0.25s ease-out;
+    transform-origin: 0 0;
   }
 
-  .form-input--select {
-    color: color(dark-text);
+  .form-input-zip--can {
+    padding: 1.3rem ms(0) 0.4rem;
+  }
+
+  .form-label-zip--can {
+    transform: translateY(0.45rem) scale(0.8);
   }
 }
 
@@ -281,7 +279,6 @@ select {
   border-radius: size(normal-corners);
   background: color(background);
   cursor: auto;
-  transition: padding 0.25s ease-out;
 
   &:not(.form-input--checkbox) {
     appearance: none;
@@ -298,9 +295,30 @@ select {
     border-color: color(accent);
   }
 }
-
 .form-input::placeholder {
   color: color(dark-text);
+}
+
+.form-input {
+  &:-webkit-autofill {
+    padding: 1.3rem ms(0) 0.4rem;
+    -webkit-text-fill-color: color(text);
+    box-shadow: 0 0 0 ms(6) color(background) inset;
+
+    & + .form-label {
+      transform: translateY(0.45rem) scale(0.8);
+    }
+  }
+
+  &.form-input--select:-webkit-autofill {
+    padding: 1.3rem ms(0) 0.4rem;
+  }
+}
+
+.form-input--select:-webkit-autofill {
+  & ~ .form-label {
+    transform: translateY(0.45rem) scale(0.8);
+  }
 }
 
 // Autoprefixer isn't adding -moz prefix, and Firefox needs opacity to be set


### PR DESCRIPTION
Related to PR https://github.com/CasperSleep/Casper/pull/4790.

This changes instances where the required label was hidden until a user starts typing.

This removes the placeholder text and displays the label upfront, animating its position via transform once a user starts typing.

I'm sure you'll notice the use of `-webkit-autofill`. The reasoning for this is a nice-to-have that adds a little polish to browser autocomplete. Functionally, it works fine without these styles, but in the instance where a user starts the autocomplete process and hovers over a saved autocomplete address (before clicking), the styling looks like:

![screen shot 2016-09-06 at 11 54 22 am](https://cloud.githubusercontent.com/assets/8405274/18281290/5386f11c-742a-11e6-8190-641ebe6ca277.png)

Because this is only visible when a user hovers on autocomplete and before clicking, I think it's fine for other browsers. Other sites that follow similar design patterns with labels, notably Warby Parker, still possess a similar issue (autocompleted info is cut off by background): 

![screen shot 2016-09-06 at 11 49 10 am](https://cloud.githubusercontent.com/assets/8405274/18281359/a3249ab2-742a-11e6-8ca4-10e607eae6a8.png)

Vendor prefixes aren't ideal, but it does make it look and read a lot better, even if it's a very short in-between state of selecting an autocomplete address:

![screen shot 2016-09-06 at 11 53 42 am](https://cloud.githubusercontent.com/assets/8405274/18281430/d549efd8-742a-11e6-831b-df6297a352cd.png)
