### PR TITLE
Styling for iOS checkbox/radio

### DIFF
--- a/src/forms/_base.scss
+++ b/src/forms/_base.scss
@@ -57,6 +57,10 @@ input[type="radio"] {
   -webkit-appearance: radio;
   border-radius: 50%;
   border: 1px solid color(text);
+
+  &:checked {
+    background-color: color(gray);
+  }
 }
 
 // Get rid of number dropdown "spinners" for browsers
@@ -334,11 +338,18 @@ select {
 
 .form-input--checkbox {
   width: auto;
-  border: 0;
-  border-radius: 0;
   margin: 0;
   padding: 0;
   cursor: pointer;
+
+  // iOS styling
+  background: color(light-background);
+  border: 1px solid color(gray);
+  border-radius: 5px;
+
+  &:checked {
+    background: color(gray);
+  }
 }
 
 .form-input--radio {


### PR DESCRIPTION
### Issues

Fixing checkboxes/radios to use default iOS styling

Trello: https://trello.com/c/bOtRmlwl/239-1-checkout-remove-checkmark-icon-for-mobile
### Steps to Reproduce
1. `npm link` in `nightshade-core`
2. `npm link @casper/nightshade-core` in Casper Rails
3. Go to billing page on iOS
### Updated styling

![screen shot 2016-09-08 at 1 47 22 pm](https://cloud.githubusercontent.com/assets/982115/18360191/07273532-75cb-11e6-9fb0-53cefe6fc8f6.png)
![screen shot 2016-09-08 at 1 47 27 pm](https://cloud.githubusercontent.com/assets/982115/18360195/090cb188-75cb-11e6-8152-5da1bad09b8d.png)
### Old styling

![screen shot 2016-09-08 at 1 48 11 pm](https://cloud.githubusercontent.com/assets/982115/18360206/15173b1a-75cb-11e6-979d-cfcc1a5ac829.png)
![screen shot 2016-09-08 at 1 48 15 pm](https://cloud.githubusercontent.com/assets/982115/18360209/1682771c-75cb-11e6-8772-e8c12e8f6966.png)
