### PR TITLE
Form label less emphasis

### DIFF
--- a/src/forms/_base.scss
+++ b/src/forms/_base.scss
@@ -195,6 +195,19 @@ select {
   & + .form-input {
     margin-top: ms(-6);
   }
+
+  &.form-label--less-emphasis {
+    @include calibre-medium;
+    font-size: ms(0);
+    letter-spacing: size(smaller-tracking);
+    text-transform: none;
+
+    &.form-label--radio-check {
+      .form-input--checkbox {
+        top: 6px;
+      }
+    }
+  }
 }
 
 .form-field--float {

--- a/src/forms/_base.scss
+++ b/src/forms/_base.scss
@@ -184,20 +184,16 @@ select {
 .form-field {
   position: relative;
   margin-bottom: ms(3);
+}
 
-  // @todo Turn this into a modifier when nightshade styles port over (e.g. form-field--standard)
-  &:not(.form-field--float) {
+.form-label {
+  @include heading-5;
+  display: block;
+  margin-bottom: ms(-6);
+  color: color(text);
 
-    .form-label {
-      @include heading-5;
-      display: block;
-      margin-bottom: ms(-6);
-      color: color(text);
-
-      & + .form-input {
-        margin-top: ms(-6);
-      }
-    }
+  & + .form-input {
+    margin-top: ms(-6);
   }
 }
 
@@ -226,6 +222,11 @@ select {
     transform: translateY(1rem) scale(1);
     transition: transform 0.25s ease-out;
     transform-origin: 0 0;
+    text-transform: none;
+
+    & + .form-input {
+      margin-top: 0;
+    }
   }
 
   .form-input-zip--can {


### PR DESCRIPTION
### Issues

Adding a `.form-label--less-emphasis` modifier.

![screen shot 2016-10-24 at 1 50 30 pm](https://cloud.githubusercontent.com/assets/982115/19657138/dae1bff2-99f0-11e6-8446-8ee3388ebbcc.png)
