### PR TITLE
V2.19.0

### DIFF
--- a/src/banners/_cta_banner.scss
+++ b/src/banners/_cta_banner.scss
@@ -10,7 +10,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: ms(16);
+  min-height: ms(16);
   padding: ms(8) ms(2);
   background-repeat: no-repeat;
   background-size: cover;

--- a/src/blocks/_ie_styles.scss
+++ b/src/blocks/_ie_styles.scss
@@ -15,7 +15,7 @@
 }
 
 .block-item-image,
-.block-item-description,
+.block-item-heading,
 .block-item-body {
  @include margin-auto;
 }

--- a/src/blocks/blocks.macros.html
+++ b/src/blocks/blocks.macros.html
@@ -18,7 +18,7 @@
   <figure class="block-item-image">
     {{ svg(icon) }}
   </figure>
-  <h4 class="heading-3 block-item-heading">{{ content|safe }}</h4>
+  <h4 class="block-item-heading">{{ content|safe }}</h4>
 </div>
 {% endmacro %}
 

--- a/src/callout/_base.scss
+++ b/src/callout/_base.scss
@@ -17,6 +17,7 @@
 }
 
 .callout-heading {
+  @include heading;
   max-width: 27em;
   font-size: ms(0);
 

--- a/src/callout/callout.macros.html
+++ b/src/callout/callout.macros.html
@@ -18,7 +18,7 @@
     {{ svg(icon) }}
   {% endif %}
 
-  {% if heading %}<h2 class="callout-heading -dark">{{ heading }}</h2>{% endif %}
+  {% if heading %}<h2 class="callout-heading">{{ heading }}</h2>{% endif %}
   {{ caller() }}
 </div>
 {% endmacro %}

--- a/src/content_panel/_base.scss
+++ b/src/content_panel/_base.scss
@@ -56,6 +56,7 @@
 
 .content-panel-heading {
   @include margin-auto;
+  @include heading-4;
 }
 
 .content-panel-content-body {

--- a/src/content_panel/panel.macros.html
+++ b/src/content_panel/panel.macros.html
@@ -20,7 +20,7 @@
   </figure>
   <div class="content-panel-content">
     <div class="content-panel-content-body">
-      <h2 class="content-panel-heading heading-2">{{ heading }}</h2>
+      <h2 class="content-panel-heading">{{ heading }}</h2>
       {{ caller() }}
     </div>
   </div>

--- a/src/footer/_base.scss
+++ b/src/footer/_base.scss
@@ -34,7 +34,6 @@
 
 .footer-bottom {
   background-color: color(dark-blue);
-  padding: 0 ms(5) ms(-2);
 
   @include respond-at-and-above($break-medium) {
     padding-bottom: ms(5);

--- a/src/footer/footer.macros.html
+++ b/src/footer/footer.macros.html
@@ -15,14 +15,6 @@
   <div class="footer-bottom">
     <nav class="footer-nav r-inner">
       <div class="footer-nav-group footer-nav-group--bottom">
-        <span class="footer-nav-country-icons">
-          <a class="footer-nav-group-link footer-nav-group-link--country" href="?country_id=49">
-            {{ icon('usa', size='small') }}
-          </a>
-          <a class="footer-nav-group-link footer-nav-group-link--country" href="?country_id=204">
-            {{ icon('canada', size='small') }}
-          </a>
-        </span>
         <div class="footer-nav-group-text--mobile">
           <span class="footer-nav-group-text--bottom">
             &copy;
@@ -30,12 +22,10 @@
               document.write(new Date().getFullYear());
             </script>
           </span>
-          <span class="footer-nav-group-text--bottom footer-nav-group-text--address">
-            45 Bond St. New York, NY 10012
-          </span>
           <span>
-            <a class="footer-nav-group-link footer-nav-group-text--bottom" href="https://casper.com/privacy">Privacy</a>
-            <a class="footer-nav-group-link footer-nav-group-text--bottom" href="https://casper.com/terms">Terms</a>
+            {% for link in footer_links %}
+              <a class="footer-nav-group-link footer-nav-group-text--bottom" href="{{ link.url }}">{{ link.title }}</a>
+            {% endfor %}
           </span>
         </div>
       </div>

--- a/src/hero/_base.scss
+++ b/src/hero/_base.scss
@@ -24,6 +24,7 @@
 
 .hero-heading,
 .hero-subheading {
+  @include heading;
   color: color(primary);
 }
 

--- a/src/layout/regions.macros.html
+++ b/src/layout/regions.macros.html
@@ -181,16 +181,19 @@
         {{ icon.svg("logo")}}
         <span class="nav-item-text is-invisible">Home</span>
       </a>
-      <ul class="nav-main-group nav-main-group--user">
-        <li role="presentation">
-          <span class="phone-number js-a-sup-phone">
-            <a class="nav-item" data-track-click-target="phone" href="tel:1{{ phone_number|replace('-', '') }}">
-              {{ icon.icon("phone")}}
-              {{ phone_number }}
-            </a>
-          </span>
-        </li>
-      </ul>
+
+      {% if phone_number %}
+        <ul class="nav-main-group nav-main-group--user">
+          <li role="presentation">
+            <span class="phone-number js-a-sup-phone">
+              <a class="nav-item" data-track-click-target="phone" href="tel:1{{ phone_number|replace('-', '') }}">
+                {{ icon.icon("phone")}}
+                {{ phone_number }}
+              </a>
+            </span>
+          </li>
+        </ul>
+      {% endif %}
     </nav>
   </div>
 </header>

--- a/src/value_props/_base.scss
+++ b/src/value_props/_base.scss
@@ -4,6 +4,11 @@
  * @overview Value props with side by side content and images
  */
 
+.value-prop {
+  width: 100%;
+  position: relative;
+}
+
 .value-prop-inner {
   padding: ms(8) 0;
 
@@ -55,6 +60,27 @@
 
 .value-prop-heading {
   @include margin-auto;
+  @include heading-4;
   margin-bottom: ms(-1);
-  font-size: ms(0);
+
+}
+
+.value-prop  {
+  &.value-prop--no-image {
+    padding-bottom: ms(0);
+
+    @include respond-at-and-above($break-medium) {
+      width: 50%;
+      padding: ms(1) ms(0);
+    }
+
+    .value-prop-image {
+      display: none;
+    }
+
+    .value-prop-content {
+      width: 100%;
+      max-width: none;
+    }
+  }
 }

--- a/src/value_props/_ie_styles.scss
+++ b/src/value_props/_ie_styles.scss
@@ -16,3 +16,8 @@
     margin: 0 7vw 0 0;
   }
 }
+
+.value-prop--no-image {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/value_props/props.macros.html
+++ b/src/value_props/props.macros.html
@@ -1,5 +1,6 @@
+
 {#
-  * @overview Macros for Value Props with side by side content and images.
+  * @overview Value props display heading and content and often have an image
   * @module Value Props
 #}
 
@@ -7,20 +8,28 @@
   * Renders a value prop with content and image.
   * @param {string} heading - Heading text content
   * @param {string} content - Panel body copy
-  * @param {string} image_path - Panel image or graphic path
+  * @param {string} [image_path] - Panel image or graphic path
   * @param {string} [image_description] - Image description alt text
   * @param {string} [image_position] - Image position (left or right)
   * @param {string} [class] - Class name for style or JS targeting
   * @param {string} [id] - ID for JS targeting
 #}
-{% macro value_prop(heading, content, image_path, image_description=null, image_position=null, class=null, id=null) %}
-<div class="value-prop{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
+
+
+{% macro value_prop(heading, content, image_path=null, image_description=null, image_position=null, class=null, id=null) %}
+{% set variant_without_image = "value-prop--no-image" if not image_path %}
+
+<div class="value-prop {{ variant_without_image }}{% if class %} {{ class }}{% endif %}"{% if id %} id="{{ id }}"{% endif %}>
   <div class="value-prop-inner r-inner">
-    <figure class="value-prop-image{% if image_position %} value-prop-image--{{ image_position }}{% endif %}">
-      <img src="{{ image_path }}" alt="{{ image_description }}">
-    </figure>
+
+    {% if image_path %}
+      <figure class="value-prop-image{% if image_position %} value-prop-image--{{ image_position }}{% endif %}">
+        <img src="{{ image_path }}" alt="{{ image_description }}">
+      </figure>
+    {% endif %}
+
     <div class="value-prop-content">
-      <h3 class="value-prop-heading -dark">{{ heading }}</h3>
+      <h3 class="value-prop-heading">{{ heading }}</h3>
       <p class="value-prop-body">{{ content|safe }}</p>
     </div>
   </div>


### PR DESCRIPTION
### Issues

Assortment of improvements for nightshade core that affects the storefront-static repo

* Remove utility classes on macros to make them more flexible. 
* Update footer to work for all countries. 
* Some IE fixes

I have additional PRs for strorefront static to bring it up to date with production.

### Todos

- [x] Write up testing steps for storefront static
- [x] Code/Review Testing
- [ ] Bump version

### Impacted Areas

- All headings except Upgrade section heading 
- Value props
- Footer

### Known Issues

Until updates are made to storefront static the following modules are not in parity with the live site. Most have issues at certain breakpoints. 

**All browsers**

- Upgrade callout missing heading
- Footer links and text are missing

**IE only**

- Awards
- Value props at table-ish sizes

### Steps to Reproduce

#### On Storefront Static

These are screenshots of `master` branch without and with the changes in this branch changes. Areas that appear to be regressions from current live site will be addressed in separate commits to `storefront-static`. 

##### Chrome 

**Before/without patch (current state of master)**
![ease-before-patch](https://cloud.githubusercontent.com/assets/51812/22262821/6195a422-e240-11e6-85b5-2b55b0797939.png)

**After/with patch**
![ease-after-patch](https://cloud.githubusercontent.com/assets/51812/22264395/c7d16f82-e245-11e6-8b6c-20349e13a3d7.png)

##### IE

**IE Before**
![ease-ie-before-patch](https://cloud.githubusercontent.com/assets/51812/22264004/787e4d52-e244-11e6-892f-3ebff11e5d6e.png)

**IE After**
![ease-ie-after-patch](https://cloud.githubusercontent.com/assets/51812/22264026/8d3c4a32-e244-11e6-84d0-bf278a817a56.png)

To test this patch on Storefront static, create a link as outlined in directions below 👇 

#### Ensure no regressions on Casper.com Rails repo

- Change to this directory and branch. 
  - Run `nvm current`. 
  - If version is not `5.10.1`, `nvm use 5.10.1`.
- Create a link `npm link`
- Link repo to Casper Rails site `npm link @casper/nightshade-core`
- Click through PDPs, there should be any regressions

