### PR TITLE
remove .content-panel-heading heading styles

### DIFF
--- a/src/content_panel/_base.scss
+++ b/src/content_panel/_base.scss
@@ -56,7 +56,6 @@
 
 .content-panel-heading {
   @include margin-auto;
-  @include heading-4;
 }
 
 .content-panel-content-body {

--- a/src/content_panel/panel.macros.html
+++ b/src/content_panel/panel.macros.html
@@ -20,7 +20,7 @@
   </figure>
   <div class="content-panel-content">
     <div class="content-panel-content-body">
-      <h2 class="content-panel-heading">{{ heading }}</h2>
+      <h2 class="content-panel-heading heading-4">{{ heading }}</h2>
       {{ caller() }}
     </div>
   </div>


### PR DESCRIPTION
This commit (https://github.com/CasperSleep/nightshade-core/commit/d105a7f29d9786e8e2b97ec11b6da5fca7eb0f81) caused the `.content-panel-heading` on storefront to shrink to the `heading-4` size. This removes the heading style from the `.content-panel-heading` and applies it to the one usage on the panel macro.

----------------------
Before:
![screen shot 2017-02-22 at 1 55 40 pm](https://cloud.githubusercontent.com/assets/1414363/23227382/c486ee7e-f906-11e6-8ffb-c438a1905813.png)
After:
![screen shot 2017-02-22 at 1 57 55 pm](https://cloud.githubusercontent.com/assets/1414363/23227445/f2c164f4-f906-11e6-8ca2-521b5dc11af0.png)
