### PR TITLE
Remove reference to missing icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casper/nightshade-core",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "description": "Casper pattern and style scss library. Under development.",
   "scripts": {
     "eslint": "./node_modules/.bin/eslint src",

--- a/src/forms/_base.scss
+++ b/src/forms/_base.scss
@@ -355,10 +355,6 @@ select {
 
 .form-input--select {
   padding-right: size(large);
-  background-image: image-url("nightshade/icons/select-arrow.svg");
-  background-repeat: no-repeat;
-  background-position: right 15px center;
-  background-size: 12px 8px;
   border-radius: size(normal-corners);
   cursor: pointer;
 


### PR DESCRIPTION
### Issues

Removes reference to non-existent icon

### Steps to Reproduce

The way I found it was in the Casper repo, if you go to checkout and get to the address form, you'll notice a 404 for a missing asset in the console.

