### PR TITLE
Remove unused zipcode style for Canada

### DIFF
--- a/src/forms/_base.scss
+++ b/src/forms/_base.scss
@@ -247,9 +247,6 @@ select {
     padding: 1.3rem ms(0) 0.4rem;
   }
 
-  .form-label-zip--can {
-    transform: translateY(0.45rem) scale(0.8);
-  }
 }
 
 


### PR DESCRIPTION
Remove Canada specific css styling.

link to staging environment
https://casper-staging-pr-6407.herokuapp.com/ca/en/checkout/address