### PR TITLE
Don't add special rules for webkit autofill

### DIFF
--- a/src/forms/_base.scss
+++ b/src/forms/_base.scss
@@ -317,7 +317,6 @@ select {
 
 .form-input {
   &:-webkit-autofill {
-    padding: 1.3rem ms(0) 0.4rem;
     -webkit-text-fill-color: color(text);
     box-shadow: 0 0 0 ms(6) color(background) inset;
 


### PR DESCRIPTION
Browser style has changed, making this override unnecessary.

With override: 

![image](https://cloud.githubusercontent.com/assets/925735/24372944/ad60a8dc-12fd-11e7-81b4-5ca98291c60c.png)

Without override:

![image](https://cloud.githubusercontent.com/assets/925735/24372972/c2bcaa0a-12fd-11e7-9855-8175d149d51e.png)
