### PR TITLE
Remove "1" prefix to tel: links, breaks int'l phone numbers

### DIFF
--- a/src/footer/footer.macros.html
+++ b/src/footer/footer.macros.html
@@ -32,7 +32,7 @@
 
       {% if not simple %}
       <div class="footer-nav-group footer-nav-group--right">
-        <a class="footer-nav-group-link footer-nav-group-link--contact footer-nav-group-link--contact-phone" href="tel:1{{ phone_number|replace('-', '') }}">
+        <a class="footer-nav-group-link footer-nav-group-link--contact footer-nav-group-link--contact-phone" href="tel:{{ phone_number|replace('-', '') }}">
           {{ icon('phone', size='x-small') }}
           <span class="footer-nav-group-text--bottom footer-nav-group-text--contact">{{ phone_number }}</span>
         </a>

--- a/src/layout/regions.macros.html
+++ b/src/layout/regions.macros.html
@@ -186,7 +186,7 @@
         <ul class="nav-main-group nav-main-group--user">
           <li role="presentation">
             <span class="phone-number js-a-sup-phone">
-              <a class="nav-item" data-track-click-target="phone" href="tel:1{{ phone_number|replace('-', '') }}">
+              <a class="nav-item" data-track-click-target="phone" href="tel:{{ phone_number|replace('-', '') }}">
                 {{ icon.icon("phone")}}
                 {{ phone_number }}
               </a>


### PR DESCRIPTION
Instead, `phone_number` should contain a valid, locally dialable phone number.

We already format the phone numbers properly in the static storefront. This `1` macro actually invalidates all of these `tel:` links currently, not just int'l phone numbers.

### Issues

Macros added `1` in front of every phone no. in `tel:` links. 

### Todos

Release NPM package after merge ^^

### Impacted Areas

What components will be affected?

### Steps to Reproduce

Ex.: casper.com/welcome, top right corner:

![screen shot 2017-08-04 at 13 39 42](https://user-images.githubusercontent.com/164400/28967238-88070cd8-791a-11e7-81a1-28646de3d344.png)


